### PR TITLE
Fixes #134 where the rownum column was not populated in the tables

### DIFF
--- a/RowsetImportEngine/Helpers/ConvertHelper.cs
+++ b/RowsetImportEngine/Helpers/ConvertHelper.cs
@@ -6,6 +6,9 @@ namespace RowsetImportEngine.Helpers
     {
         public static object ValidateData<T>(object columndata, out object data)
         {
+            //IsValid() and ConvertFrom() only work if you do valid converts from one data type to another.
+            //Those FAIL if you attempt to convert from one type to the same type (e.g. converting Int64 to Int64 fails)
+
             try
             {
                 data = null;

--- a/RowsetImportEngine/TextRowsetImporter.cs
+++ b/RowsetImportEngine/TextRowsetImporter.cs
@@ -631,8 +631,8 @@ namespace RowsetImportEngine
 													c.Data = DateTime.Now.ToUniversalTime().ToString("yyyy-mm-dd hh:mm:ss");
 													break;
 												case "ROWNUMBER":
-													c.Data = this.CurrentRowset.RowsInserted;
-													break;
+													c.Data = this.CurrentRowset.RowsInserted.ToString(); //have to make a string because ValidateData() would fail to convert from long to long
+                                                    break;
 												default:
 													c.Data = null;
 													break;


### PR DESCRIPTION
After long debugging we found that the new helper function introduced public static object ValidateData<T>(object columndata, out object data) was failing to convert valid numeric strings to BigInt data types for the Rownumber tokenvalue. The reason, it turns out is that TypeConverter.IsValid() and TypeConverter.ConvertFrom() only work if you do valid converts from one data type to another. But those FAIL if you attempt to convert from one type to the same type (e.g. converting Int64 to Int64 fails). Since RowsInserted in
c.Data = this.CurrentRowset.RowsInserted was actually a long, converting from long to long was leading a null value being returned and stored in c.Data.
Now, we purposely cast RowsInserted to a string and that causes a successful data validation.

Co-Authored-By: Todd <22751647+gambit9009@users.noreply.github.com>