### PR TITLE
New best practices rule for unhealthy AG + checking for gaps in data collection + virtual file IO stats rowset

### DIFF
--- a/NexusReports/AnalysisSummary_C.rdl
+++ b/NexusReports/AnalysisSummary_C.rdl
@@ -17,19 +17,32 @@
       <Query>
         <DataSourceName>DataSource_SqlNexus_Private</DataSourceName>
         <CommandText>DECLARE @sql VARCHAR(MAX) 
-IF OBJECT_ID ('tbl_RUNTIMES') IS NOT NULL
+
+IF (OBJECT_ID ('tbl_RUNTIMES') IS NOT NULL)
 BEGIN
-	SET @sql = 'SELECT (runtime) AS StartTime FROM tbl_RUNTIMES'
-	EXEC (@sql)
+	IF EXISTS(SELECT TOP 1 (runtime) AS StartTime FROM tbl_RUNTIMES)
+	BEGIN
+		SET @sql = 'SELECT MIN(runtime) AS StartTime FROM tbl_RUNTIMES'
+		EXEC (@sql)
+	END
+	ELSE
+		SELECT CAST ('2000/1/1 00:00:01' AS DATETIME) AS StartTime
+
 END
 ELSE IF OBJECT_ID ('tbl_REQUESTS') IS NOT NULL
 BEGIN
-	SET @sql = 'SELECT (runtime) AS StartTime  FROM tbl_REQUESTS'
-	EXEC (@sql)
+
+	IF EXISTS(SELECT TOP 1 (runtime) AS StartTime FROM tbl_REQUESTS)
+	BEGIN
+		SET @sql = 'SELECT MIN(runtime) AS StartTime  FROM tbl_REQUESTS'
+		EXEC (@sql)
+	END
+	ELSE
+		SELECT CAST ('2000/1/1 00:00:02' AS DATETIME) AS StartTime
 END
 ELSE
 BEGIN
-	SELECT CAST ('2000/1/1' AS DATETIME) AS StartTime
+	SELECT CAST ('2000/1/1 00:00:03' AS DATETIME) AS StartTime
 END</CommandText>
         <rd:UseGenericDesigner>true</rd:UseGenericDesigner>
       </Query>
@@ -46,17 +59,27 @@ END</CommandText>
         <CommandText>DECLARE @sql VARCHAR(MAX) 
 IF OBJECT_ID ('tbl_RUNTIMES') IS NOT NULL
 BEGIN
-	SET @sql = 'SELECT (runtime) AS EndTime FROM tbl_RUNTIMES'
-	EXEC (@sql)
+	IF EXISTS(SELECT TOP 1 (runtime) AS StartTime FROM tbl_RUNTIMES)
+	BEGIN
+		SET @sql = 'SELECT MAX(runtime) AS EndTime FROM tbl_RUNTIMES'
+		EXEC (@sql)
+	END
+	ELSE
+		SELECT CAST ('2099/1/1 00:00:01' AS DATETIME) AS EndTime
 END
 ELSE IF OBJECT_ID ('tbl_REQUESTS') IS NOT NULL
 BEGIN
-	SET @sql = 'SELECT (runtime) AS EndTime  FROM tbl_REQUESTS'
-	EXEC (@sql)
+	IF EXISTS(SELECT TOP 1 (runtime) AS StartTime FROM tbl_REQUESTS)
+	BEGIN
+		SET @sql = 'SELECT MAX(runtime) AS EndTime  FROM tbl_REQUESTS'
+		EXEC (@sql)
+	END
+	ELSE
+		SELECT CAST ('2000/1/1 00:00:02' AS DATETIME) AS EndTime
 END
 ELSE
 BEGIN
-	SELECT CAST ('2099/1/1' AS DATETIME) AS EndTime
+	SELECT CAST ('2099/1/1 00:00:03' AS DATETIME) AS EndTime
 END</CommandText>
         <rd:UseGenericDesigner>true</rd:UseGenericDesigner>
       </Query>
@@ -671,7 +694,6 @@ Fields!Report.Value = "", Nothing)</ReportName>
                             <PaddingBottom>2pt</PaddingBottom>
                           </Style>
                         </Textbox>
-                        <rd:Selected>true</rd:Selected>
                       </CellContents>
                     </TablixCell>
                   </TablixCells>

--- a/NexusReports/AnalysisSummary_C.rdl
+++ b/NexusReports/AnalysisSummary_C.rdl
@@ -646,6 +646,7 @@ Fields!Report.Value = "Server Configuration", "ServerConfiguration_C",
 Fields!Report.Value = "Missing Indexes", "Missing Indexes_C", 
 Fields!Report.Value = "Spinlock Stats", "Spinlock Stats_C",
 Fields!Report.Value = "Loaded Modules", "Loaded Modules_C",
+Fields!Report.Value = "AlwaysOn Report", "AlwaysOn_AGBasics_C",
 Fields!Report.Value = "data imported with older SQLNexus version", Nothing, 
 Fields!Report.Value = "", Nothing)</ReportName>
                                 </Drillthrough>

--- a/RowsetImportEngine/TextRowsets.xml
+++ b/RowsetImportEngine/TextRowsets.xml
@@ -3866,7 +3866,21 @@
       </KnownColumns>
     </Rowset>
 
+    <Rowset name="tbl_dm_io_virtual_file_stats" enabled="true" identifier="-- file_io_stats --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="runtime" type="RowsetImportEngine.DateTimeColumn"/>
+        <Column name="runtime_utc" type="RowsetImportEngine.DateTimeColumn"/>
+        <Column name="database_name" type="RowsetImportEngine.VarCharColumn" length="40"/>
+        <Column name="Physical_Name" type="RowsetImportEngine.VarCharColumn" length="256"/>
+        <Column name="File_Size_MB" type="RowsetImportEngine.DecimalColumn" />
+        <Column name="Average_Read_Latency" type="RowsetImportEngine.DecimalColumn" />
+        <Column name="Average_Write_Latency" type="RowsetImportEngine.DecimalColumn"/>
+        <Column name="Average_Bytes_Read " type="RowsetImportEngine.BigIntColumn"/>
+        <Column name="Average_Bytes_Write " type="RowsetImportEngine.BigIntColumn"/>
+      </KnownColumns>
+    </Rowset>
 
+    
   </KnownRowsets>
 </TextImport>
 

--- a/sqlnexus/PerfStatsAnalysis.sql
+++ b/sqlnexus/PerfStatsAnalysis.sql
@@ -2381,7 +2381,7 @@ BEGIN
 		BEGIN
 			UPDATE tbl_AnalysisSummary
 			SET [Status] = 1, 
-			[Description] =  'Found a query plan with a optimizer timeout. File ''' + @FileName + ''' contains an example query plan, with Statement text starting like this:''' + CHAR(13) + CHAR(10) + CHAR(13) + CHAR(10) +  @StmtTxt + '''. ' + CHAR(13) + CHAR(10) +  CHAR(13) + CHAR(10) +'An optimizer timeout can cause a choice of query that runs longer than expected and consume more resources. Examine queries for potential optimization '
+			[Description] =  'Found a query plan with an optimizer timeout. File ''' + @FileName + ''' contains an example query plan, with Statement text starting like this:''' + CHAR(13) + CHAR(10) + CHAR(13) + CHAR(10) +  @StmtTxt + '''. ' + CHAR(13) + CHAR(10) +  CHAR(13) + CHAR(10) +'An optimizer timeout can cause a choice of query that runs longer than expected and consume more resources. Examine queries for potential optimization '
 			WHERE [Name] = OBJECT_NAME(@@PROCID)
 		END
 	END

--- a/sqlnexus/PerfStatsAnalysis.sql
+++ b/sqlnexus/PerfStatsAnalysis.sql
@@ -2738,7 +2738,7 @@ BEGIN
 				@con_state = connected_state_desc, 
 				@sync_health_state = synchronization_health_desc
 		FROM tbl_hadr_ag_replica_states
-		WHERE operational_state_desc <> 'ONLINE' 
+		WHERE operational_state_desc IN ('OFFLINE', 'FAILED', 'FAILED_NO_QUORUM')
 				OR synchronization_health_desc  <> 'HEALTHY'
 
 		IF (@@ROWCOUNT > 0 and @avail_group_name IS NOT NULL)

--- a/sqlnexus/Properties/AssemblyInfo.cs
+++ b/sqlnexus/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("7.23.02.08")]
-[assembly: AssemblyFileVersion("7.23.02.08")]
+[assembly: AssemblyVersion("7.23.03.16")]
+[assembly: AssemblyFileVersion("7.23.03.16")]

--- a/sqlnexus/Properties/app.manifest
+++ b/sqlnexus/Properties/app.manifest
@@ -4,7 +4,7 @@
     <security>
       <applicationRequestMinimum>
         <defaultAssemblyRequest permissionSetReference="Custom" />
-        <PermissionSet class="System.Security.PermissionSet" version="1" Unrestricted="true" ID="Custom" SameSite="site" />
+        <PermissionSet class="System.Security.PermissionSet" version="1" ID="Custom" SameSite="site" Unrestricted="true" />
       </applicationRequestMinimum>
     </security>
   </trustInfo>

--- a/sqlnexus/Reports/AnalysisSummary_C.rdlC
+++ b/sqlnexus/Reports/AnalysisSummary_C.rdlC
@@ -17,19 +17,32 @@
       <Query>
         <DataSourceName>DataSource_SqlNexus_Private</DataSourceName>
         <CommandText>DECLARE @sql VARCHAR(MAX) 
-IF OBJECT_ID ('tbl_RUNTIMES') IS NOT NULL
+
+IF (OBJECT_ID ('tbl_RUNTIMES') IS NOT NULL)
 BEGIN
-	SET @sql = 'SELECT (runtime) AS StartTime FROM tbl_RUNTIMES'
-	EXEC (@sql)
+	IF EXISTS(SELECT TOP 1 (runtime) AS StartTime FROM tbl_RUNTIMES)
+	BEGIN
+		SET @sql = 'SELECT MIN(runtime) AS StartTime FROM tbl_RUNTIMES'
+		EXEC (@sql)
+	END
+	ELSE
+		SELECT CAST ('2000/1/1 00:00:01' AS DATETIME) AS StartTime
+
 END
 ELSE IF OBJECT_ID ('tbl_REQUESTS') IS NOT NULL
 BEGIN
-	SET @sql = 'SELECT (runtime) AS StartTime  FROM tbl_REQUESTS'
-	EXEC (@sql)
+
+	IF EXISTS(SELECT TOP 1 (runtime) AS StartTime FROM tbl_REQUESTS)
+	BEGIN
+		SET @sql = 'SELECT MIN(runtime) AS StartTime  FROM tbl_REQUESTS'
+		EXEC (@sql)
+	END
+	ELSE
+		SELECT CAST ('2000/1/1 00:00:02' AS DATETIME) AS StartTime
 END
 ELSE
 BEGIN
-	SELECT CAST ('2000/1/1' AS DATETIME) AS StartTime
+	SELECT CAST ('2000/1/1 00:00:03' AS DATETIME) AS StartTime
 END</CommandText>
         <rd:UseGenericDesigner>true</rd:UseGenericDesigner>
       </Query>
@@ -46,17 +59,27 @@ END</CommandText>
         <CommandText>DECLARE @sql VARCHAR(MAX) 
 IF OBJECT_ID ('tbl_RUNTIMES') IS NOT NULL
 BEGIN
-	SET @sql = 'SELECT (runtime) AS EndTime FROM tbl_RUNTIMES'
-	EXEC (@sql)
+	IF EXISTS(SELECT TOP 1 (runtime) AS StartTime FROM tbl_RUNTIMES)
+	BEGIN
+		SET @sql = 'SELECT MAX(runtime) AS EndTime FROM tbl_RUNTIMES'
+		EXEC (@sql)
+	END
+	ELSE
+		SELECT CAST ('2099/1/1 00:00:01' AS DATETIME) AS EndTime
 END
 ELSE IF OBJECT_ID ('tbl_REQUESTS') IS NOT NULL
 BEGIN
-	SET @sql = 'SELECT (runtime) AS EndTime  FROM tbl_REQUESTS'
-	EXEC (@sql)
+	IF EXISTS(SELECT TOP 1 (runtime) AS StartTime FROM tbl_REQUESTS)
+	BEGIN
+		SET @sql = 'SELECT MAX(runtime) AS EndTime  FROM tbl_REQUESTS'
+		EXEC (@sql)
+	END
+	ELSE
+		SELECT CAST ('2000/1/1 00:00:02' AS DATETIME) AS EndTime
 END
 ELSE
 BEGIN
-	SELECT CAST ('2099/1/1' AS DATETIME) AS EndTime
+	SELECT CAST ('2099/1/1 00:00:03' AS DATETIME) AS EndTime
 END</CommandText>
         <rd:UseGenericDesigner>true</rd:UseGenericDesigner>
       </Query>
@@ -671,7 +694,6 @@ Fields!Report.Value = "", Nothing)</ReportName>
                             <PaddingBottom>2pt</PaddingBottom>
                           </Style>
                         </Textbox>
-                        <rd:Selected>true</rd:Selected>
                       </CellContents>
                     </TablixCell>
                   </TablixCells>

--- a/sqlnexus/Reports/AnalysisSummary_C.rdlC
+++ b/sqlnexus/Reports/AnalysisSummary_C.rdlC
@@ -646,6 +646,7 @@ Fields!Report.Value = "Server Configuration", "ServerConfiguration_C",
 Fields!Report.Value = "Missing Indexes", "Missing Indexes_C", 
 Fields!Report.Value = "Spinlock Stats", "Spinlock Stats_C",
 Fields!Report.Value = "Loaded Modules", "Loaded Modules_C",
+Fields!Report.Value = "AlwaysOn Report", "AlwaysOn_AGBasics_C",
 Fields!Report.Value = "data imported with older SQLNexus version", Nothing, 
 Fields!Report.Value = "", Nothing)</ReportName>
                                 </Drillthrough>

--- a/sqlnexus/TextRowsets.xml
+++ b/sqlnexus/TextRowsets.xml
@@ -3866,7 +3866,21 @@
       </KnownColumns>
     </Rowset>
 
+    <Rowset name="tbl_dm_io_virtual_file_stats" enabled="true" identifier="-- file_io_stats --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="runtime" type="RowsetImportEngine.DateTimeColumn"/>
+        <Column name="runtime_utc" type="RowsetImportEngine.DateTimeColumn"/>
+        <Column name="database_name" type="RowsetImportEngine.VarCharColumn" length="40"/>
+        <Column name="Physical_Name" type="RowsetImportEngine.VarCharColumn" length="256"/>
+        <Column name="File_Size_MB" type="RowsetImportEngine.DecimalColumn" />
+        <Column name="Average_Read_Latency" type="RowsetImportEngine.DecimalColumn" />
+        <Column name="Average_Write_Latency" type="RowsetImportEngine.DecimalColumn"/>
+        <Column name="Average_Bytes_Read " type="RowsetImportEngine.BigIntColumn"/>
+        <Column name="Average_Bytes_Write " type="RowsetImportEngine.BigIntColumn"/>
+      </KnownColumns>
+    </Rowset>
 
+    
   </KnownRowsets>
 </TextImport>
 

--- a/sqlnexus/sqlnexus.csproj
+++ b/sqlnexus/sqlnexus.csproj
@@ -43,8 +43,8 @@
     <CreateWebPageOnPublish>true</CreateWebPageOnPublish>
     <WebPage>publish.htm</WebPage>
     <OpenBrowserOnPublish>false</OpenBrowserOnPublish>
-    <ApplicationRevision>8</ApplicationRevision>
-    <ApplicationVersion>7.23.02.08</ApplicationVersion>
+    <ApplicationRevision>16</ApplicationRevision>
+    <ApplicationVersion>7.23.03.16</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <PublishWizardCompleted>true</PublishWizardCompleted>
     <BootstrapperEnabled>true</BootstrapperEnabled>

--- a/sqlnexus/sqlnexus.csproj
+++ b/sqlnexus/sqlnexus.csproj
@@ -60,6 +60,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+	<HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
- Added 2 Best practices rules for AG health check and endpoint check #196
- Updated Best practices rule to detect abnormal gaps in data collection script outputs #91
- Added rowsets for the **tbl_dm_io_virtual_file_stats**: #222
**NOTE:** You can collect a SQL LogScout IO scenario to get this output
- Allow for Best Practices main report to be visible even when no Perf data is collected #223
