### PR TITLE
Adding ignorable waits CHECKPOINT_QUEUE, PARALLEL_REDO_WORKER_WAIT_WORK, QDS_ASYNC_QUEUE, PWAIT_EXTENSIBILITY_CLEANUP_TASK

### DIFF
--- a/sqlnexus/PerfStatsAnalysis.sql
+++ b/sqlnexus/PerfStatsAnalysis.sql
@@ -980,7 +980,8 @@ IF NOT EXISTS
                                       'HADR_SEEDING_SYNC_COMPLETION', 'HADR_SEEDING_TIMEOUT_TASK',
                                       'HADR_SEEDING_FILE_LIST', 'HADR_SEEDING_WAIT_FOR_COMPLETION',
                                       'HADR_DBHEALTH_INFOMAP_ACCESS', 'HADR_SEEDING_READY_FOR_RESTORE_STREAM',
-                                      'REDO_THREAD_PENDING_WORK'
+                                      'REDO_THREAD_PENDING_WORK', 'CHECKPOINT_QUEUE', 'QDS_ASYNC_QUEUE',
+                                      'PARALLEL_REDO_WORKER_WAIT_WORK', 'PWAIT_EXTENSIBILITY_CLEANUP_TASK'
                                   ) THEN
                     'IGNORABLE'
                 ELSE


### PR DESCRIPTION
The goal is to not show these as noise in the Bottleneck Analysis report.

One wait to test this is to create a SQL LogScout perfstats collection and manually go in the output file and add these wait types in the output. Then import and watch them not show up. 
You can also run this query after importing SQL Nexus and check if they are showing as "IGNORABLE" in the wait_category column

```
  use sqlnexus
  go
  select  wait_type, wait_category from tbl_OS_WAIT_STATS 
  where wait_type in 
  ('CHECKPOINT_QUEUE', 
  'QDS_ASYNC_QUEUE',
  'PARALLEL_REDO_WORKER_WAIT_WORK', 
  'PWAIT_EXTENSIBILITY_CLEANUP_TASK')

```