### PR TITLE
QueryStore_Additional_Data

### DIFF
--- a/RowsetImportEngine/TextRowsets.xml
+++ b/RowsetImportEngine/TextRowsets.xml
@@ -2235,14 +2235,11 @@
       <Column name="compatibility_level" type="RowsetImportEngine.IntColumn" />
       <Column name="query_plan_hash" type="RowsetImportEngine.VarBinaryColumn" length="8" />
       <Column name="is_forced_plan" type="RowsetImportEngine.IntColumn" />
-      <!-- 620 JAMGRIF 022024 -->
       <Column name="force_failure_count" type="RowsetImportEngine.BigIntColumn" />
       <Column name="last_force_failure_reason_desc"  type="RowsetImportEngine.VarCharColumn" length="256" />
-      <!-- 620 JAMGRIF 022024 2017+ only-->
       <Column name="plan_forcing_type_desc"  type="RowsetImportEngine.VarCharColumn" length="120" />
     </Rowset>
 
-    <!-- 620 JAMGRIF 022024 -->
     <Rowset name="tbl_dm_db_tuning_recommendations" enabled="true" identifier="--sys.dm_db_tuning_recommendations--" type="RowsetImportEngine.TextRowset">
       <Column name="reason" type="RowsetImportEngine.NVarCharColumn" length="4000" />
       <Column name="score" type="RowsetImportEngine.IntColumn" />

--- a/RowsetImportEngine/TextRowsets.xml
+++ b/RowsetImportEngine/TextRowsets.xml
@@ -2235,6 +2235,28 @@
       <Column name="compatibility_level" type="RowsetImportEngine.IntColumn" />
       <Column name="query_plan_hash" type="RowsetImportEngine.VarBinaryColumn" length="8" />
       <Column name="is_forced_plan" type="RowsetImportEngine.IntColumn" />
+      <!-- 620 JAMGRIF 022024 -->
+      <Column name="force_failure_count" type="RowsetImportEngine.BigIntColumn" />
+      <Column name="last_force_failure_reason_desc"  type="RowsetImportEngine.VarCharColumn" length="256" />
+      <!-- 620 JAMGRIF 022024 2017+ only-->
+      <Column name="plan_forcing_type_desc"  type="RowsetImportEngine.VarCharColumn" length="120" />
+    </Rowset>
+
+    <!-- 620 JAMGRIF 022024 -->
+    <Rowset name="tbl_dm_db_tuning_recommendations" enabled="true" identifier="--sys.dm_db_tuning_recommendations--" type="RowsetImportEngine.TextRowset">
+      <Column name="reason" type="RowsetImportEngine.NVarCharColumn" length="4000" />
+      <Column name="score" type="RowsetImportEngine.IntColumn" />
+      <Column name="query_id" type="RowsetImportEngine.IntColumn" />
+      <Column name="regressedPlanId" type="RowsetImportEngine.IntColumn" />
+      <Column name="recommendedPlanId" type="RowsetImportEngine.IntColumn" />
+      <Column name="regressedPlanErrorCount" type="RowsetImportEngine.IntColumn" />
+      <Column name="recommendedPlanErrorCount" type="RowsetImportEngine.IntColumn" />
+      <Column name="regressedPlanExecutionCount" type="RowsetImportEngine.IntColumn" />
+      <Column name="regressedPlanCpuTimeAverage" type="RowsetImportEngine.FloatColumn" />
+      <Column name="recommendedPlanExecutionCount" type="RowsetImportEngine.IntColumn" />
+      <Column name="recommendedPlanCpuTimeAverage" type="RowsetImportEngine.FloatColumn" />
+      <Column name="estimated_gain" type="RowsetImportEngine.FloatColumn" />
+      <Column name="error_prone" type="RowsetImportEngine.VarCharColumn" length="3" />
     </Rowset>
 
 

--- a/sqlnexus/TextRowsets.xml
+++ b/sqlnexus/TextRowsets.xml
@@ -2235,14 +2235,11 @@
       <Column name="compatibility_level" type="RowsetImportEngine.IntColumn" />
       <Column name="query_plan_hash" type="RowsetImportEngine.VarBinaryColumn" length="8" />
       <Column name="is_forced_plan" type="RowsetImportEngine.IntColumn" />
-      <!-- 620 JAMGRIF 022024 -->
       <Column name="force_failure_count" type="RowsetImportEngine.BigIntColumn" />
       <Column name="last_force_failure_reason_desc"  type="RowsetImportEngine.VarCharColumn" length="256" />
-      <!-- 620 JAMGRIF 022024 2017+ only-->
       <Column name="plan_forcing_type_desc"  type="RowsetImportEngine.VarCharColumn" length="120" />
     </Rowset>
 
-    <!-- 620 JAMGRIF 022024 -->
     <Rowset name="tbl_dm_db_tuning_recommendations" enabled="true" identifier="--sys.dm_db_tuning_recommendations--" type="RowsetImportEngine.TextRowset">
       <Column name="reason" type="RowsetImportEngine.NVarCharColumn" length="4000" />
       <Column name="score" type="RowsetImportEngine.IntColumn" />

--- a/sqlnexus/TextRowsets.xml
+++ b/sqlnexus/TextRowsets.xml
@@ -2235,6 +2235,28 @@
       <Column name="compatibility_level" type="RowsetImportEngine.IntColumn" />
       <Column name="query_plan_hash" type="RowsetImportEngine.VarBinaryColumn" length="8" />
       <Column name="is_forced_plan" type="RowsetImportEngine.IntColumn" />
+      <!-- 620 JAMGRIF 022024 -->
+      <Column name="force_failure_count" type="RowsetImportEngine.BigIntColumn" />
+      <Column name="last_force_failure_reason_desc"  type="RowsetImportEngine.VarCharColumn" length="256" />
+      <!-- 620 JAMGRIF 022024 2017+ only-->
+      <Column name="plan_forcing_type_desc"  type="RowsetImportEngine.VarCharColumn" length="120" />
+    </Rowset>
+
+    <!-- 620 JAMGRIF 022024 -->
+    <Rowset name="tbl_dm_db_tuning_recommendations" enabled="true" identifier="--sys.dm_db_tuning_recommendations--" type="RowsetImportEngine.TextRowset">
+      <Column name="reason" type="RowsetImportEngine.NVarCharColumn" length="4000" />
+      <Column name="score" type="RowsetImportEngine.IntColumn" />
+      <Column name="query_id" type="RowsetImportEngine.IntColumn" />
+      <Column name="regressedPlanId" type="RowsetImportEngine.IntColumn" />
+      <Column name="recommendedPlanId" type="RowsetImportEngine.IntColumn" />
+      <Column name="regressedPlanErrorCount" type="RowsetImportEngine.IntColumn" />
+      <Column name="recommendedPlanErrorCount" type="RowsetImportEngine.IntColumn" />
+      <Column name="regressedPlanExecutionCount" type="RowsetImportEngine.IntColumn" />
+      <Column name="regressedPlanCpuTimeAverage" type="RowsetImportEngine.FloatColumn" />
+      <Column name="recommendedPlanExecutionCount" type="RowsetImportEngine.IntColumn" />
+      <Column name="recommendedPlanCpuTimeAverage" type="RowsetImportEngine.FloatColumn" />
+      <Column name="estimated_gain" type="RowsetImportEngine.FloatColumn" />
+      <Column name="error_prone" type="RowsetImportEngine.VarCharColumn" length="3" />
     </Rowset>
 
 


### PR DESCRIPTION
Added new columns and table for QS modifications.
Added columns force_failure_count, last_force_failure_reason_desc and plan_forcing_type_desc to table sys.query_store_plan. Also, added new table tbl_dm_db_tuning_recommendations to collect auto tune recommendations from new query in SQLLogScout for sys.dm_db_tuning_recommendations. 