### PR TITLE
#364 Remove dependency on sql perf main.rdl  replication report on msmerge_subscriptions

### DIFF
--- a/NexusReports/SQL Perf Main.rdl
+++ b/NexusReports/SQL Perf Main.rdl
@@ -847,22 +847,6 @@ INSERT INTO @tbl_reports
 VALUES
 ('Replication_Topology_C', 'Replication Topology', 'Replication Topology in hierarchycal order', 1 | 2 | 4 | 8,
  'Replication', 'dbo.tbl_repl_mssubscriptions', 200, 'Replication', 1, 2000);
-INSERT INTO @tbl_reports
-(
-    ReportName,
-    ReportDisplayName,
-    ReportDescription,
-    VersionApplied,
-    Category,
-    ValidationObject,
-    SeqNo,
-    DataCollection,
-    Manditory,
-    CategorySeq
-)
-VALUES
-('Replication_Topology_C', 'Replication Topology', 'Replication Topology in hierarchycal order', 1 | 2 | 4 | 8,
- 'Replication', 'dbo.tbl_repl_msmerge_subscriptions', 200, 'Replication', 1, 2000);
 
 --AG
 INSERT INTO @tbl_reports

--- a/sqlnexus/Reports/SQL Perf Main.rdl
+++ b/sqlnexus/Reports/SQL Perf Main.rdl
@@ -847,22 +847,6 @@ INSERT INTO @tbl_reports
 VALUES
 ('Replication_Topology_C', 'Replication Topology', 'Replication Topology in hierarchycal order', 1 | 2 | 4 | 8,
  'Replication', 'dbo.tbl_repl_mssubscriptions', 200, 'Replication', 1, 2000);
-INSERT INTO @tbl_reports
-(
-    ReportName,
-    ReportDisplayName,
-    ReportDescription,
-    VersionApplied,
-    Category,
-    ValidationObject,
-    SeqNo,
-    DataCollection,
-    Manditory,
-    CategorySeq
-)
-VALUES
-('Replication_Topology_C', 'Replication Topology', 'Replication Topology in hierarchycal order', 1 | 2 | 4 | 8,
- 'Replication', 'dbo.tbl_repl_msmerge_subscriptions', 200, 'Replication', 1, 2000);
 
 --AG
 INSERT INTO @tbl_reports


### PR DESCRIPTION
Replication topology report had an unnecessary requirement on msmerge_subscriptions. Remove from the query to show the report in perf mail so that way users can see it.