### PR TITLE
Add elapsed_time_seconds column to tbl_open_transactions rowset

### DIFF
--- a/RowsetImportEngine/TextRowsets.xml
+++ b/RowsetImportEngine/TextRowsets.xml
@@ -1665,6 +1665,7 @@
         <Column name="database_transaction_begin_lsn" type="RowsetImportEngine.DecimalColumn" />
         <Column name="database_transaction_last_lsn" type="RowsetImportEngine.DecimalColumn" />
         <Column name="database_transaction_begin_time" type="RowsetImportEngine.DateTimeColumn" />
+		<Column name="elapsed_time_seconds" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_used" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_reserved" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_reserved_system" type="RowsetImportEngine.IntColumn" />

--- a/RowsetImportEngine/TextRowsets.xml
+++ b/RowsetImportEngine/TextRowsets.xml
@@ -1665,7 +1665,7 @@
         <Column name="database_transaction_begin_lsn" type="RowsetImportEngine.DecimalColumn" />
         <Column name="database_transaction_last_lsn" type="RowsetImportEngine.DecimalColumn" />
         <Column name="database_transaction_begin_time" type="RowsetImportEngine.DateTimeColumn" />
-		<Column name="elapsed_time_seconds" type="RowsetImportEngine.BigIntColumn" />
+        <Column name="elapsed_time_seconds" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_used" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_reserved" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_reserved_system" type="RowsetImportEngine.IntColumn" />

--- a/sqlnexus/TextRowsets.xml
+++ b/sqlnexus/TextRowsets.xml
@@ -1665,6 +1665,7 @@
         <Column name="database_transaction_begin_lsn" type="RowsetImportEngine.DecimalColumn" />
         <Column name="database_transaction_last_lsn" type="RowsetImportEngine.DecimalColumn" />
         <Column name="database_transaction_begin_time" type="RowsetImportEngine.DateTimeColumn" />
+		<Column name="elapsed_time_seconds" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_used" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_reserved" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_reserved_system" type="RowsetImportEngine.IntColumn" />

--- a/sqlnexus/TextRowsets.xml
+++ b/sqlnexus/TextRowsets.xml
@@ -1665,7 +1665,7 @@
         <Column name="database_transaction_begin_lsn" type="RowsetImportEngine.DecimalColumn" />
         <Column name="database_transaction_last_lsn" type="RowsetImportEngine.DecimalColumn" />
         <Column name="database_transaction_begin_time" type="RowsetImportEngine.DateTimeColumn" />
-		<Column name="elapsed_time_seconds" type="RowsetImportEngine.BigIntColumn" />
+        <Column name="elapsed_time_seconds" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_used" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_reserved" type="RowsetImportEngine.BigIntColumn" />
         <Column name="database_transaction_log_bytes_reserved_system" type="RowsetImportEngine.IntColumn" />


### PR DESCRIPTION
On this PR, we are adding the new column `elapsed_time_seconds` that has been added to the collector SQLScript_TempDB_and_Tran_Analysis.

How to test?

- Collect data with the internal Log Scout PR that has this change: 388 
- Confirm that column elapsed_time_seconds is imported into the table tbl_open_transactions
