### PR TITLE
Obscure credentials for SQL auth when launching ReadTrace and SQL Nexus with SQL Auth

### DIFF
--- a/ReadTraceNexusImporter/ReadTraceNexusImporter.cs
+++ b/ReadTraceNexusImporter/ReadTraceNexusImporter.cs
@@ -488,24 +488,26 @@ namespace ReadTrace
             if (false == this.useWindowsAuth)
             {
                 // Obscure sqlLogin: show first and last character, rest as '*'
-                string obscuredLogin;
-                if (string.IsNullOrEmpty(this.sqlLogin))
-                {
-                    obscuredLogin = ""; // Use empty string if null or empty
-                }
-                else if (this.sqlLogin.Length < 3)
-                {
-                    obscuredLogin = this.sqlLogin; // Show as-is if too short
-                }
-                else
-                {
-                    obscuredLogin = this.sqlLogin[0] + new string('*', this.sqlLogin.Length - 2) + this.sqlLogin[this.sqlLogin.Length - 1];
-                }
+                string obscuredLogin = (string.IsNullOrEmpty(this.sqlLogin) || this.sqlLogin.Length < 3)
+                   ? this.sqlLogin // Show as-is if too short
+                   : this.sqlLogin[0] + new string('*', this.sqlLogin.Length - 2) + this.sqlLogin[this.sqlLogin.Length - 1];
+
+
+                argsOut = System.Text.RegularExpressions.Regex.Replace(
+                    args,
+                    @"-U""[^""]*""",
+                    $@"-U""{obscuredLogin}""");
+
                 if (!string.IsNullOrEmpty(this.sqlPassword))
                 {
-                    argsOut = argsOut.Replace("\"" + this.sqlPassword + "\"", "\"******************\"");
+                    // Obscure password completely
+                    string obscuredPwd = "******************";
+
+                    argsOut = System.Text.RegularExpressions.Regex.Replace(
+                    argsOut,
+                    @"-P""[^""]*""",
+                    $@"-P""{obscuredPwd}""");
                 }
-                argsOut = argsOut.Replace("\"" + this.sqlLogin + "\"", "\"" + obscuredLogin + "\"");
             }
 
 


### PR DESCRIPTION
1. Build SQL Nexus in Release
2. Connect using SQL Authentication, instead of Windows Auth
    
   <img width="551" height="327" alt="image" src="https://github.com/user-attachments/assets/244788cb-949b-456f-a893-b0ba9b41f69c" />

3. Import a SQL LogScout collection that contains XEL/Trc data so that ReadTrace is used
4. Once import is done, open the SQL Nexus log to view it
    
   <img width="281" height="150" alt="image" src="https://github.com/user-attachments/assets/b4e8e149-e1ad-404f-8752-4329c2ed19e0" />

5. Look for the line where ReadTrace is used to make sure the user name and password are obscured.

   ```
   SQLNexus Information: 0 : ReadTraceNexusImporter: Cmd Line: C:\Program Files\Microsoft Corporation\RMLUtils\readtrace.exe -S"SQLSERVER" "-dsqlnexus" -U"j******n" -P"******************" -T18 -T28 -T29 ....
   ```

   