### PR TITLE
Fix code scanning alert 448 and 453: Possible loss of precision

### DIFF
--- a/sqlnexus/Spinner.cs
+++ b/sqlnexus/Spinner.cs
@@ -320,7 +320,7 @@ namespace sqlnexus
         /// <returns>PointF object</returns>
         private PointF GetControlCenterPoint(Control _objControl)
         {
-            return new PointF(_objControl.Width / 2, _objControl.Height / 2);
+            return new PointF(_objControl.Width / 2f, _objControl.Height / 2f);
         }
 
         /// <summary>


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/SqlNexus/security/code-scanning/448](https://github.com/microsoft/SqlNexus/security/code-scanning/448)

To fix the problem without changing existing functionality, we should ensure that the division operation in line 378 is performed using floating-point arithmetic. Specifically, cast one of the operands, typically `NUMBER_OF_DEGREES_CIRCLE`, to a double before dividing by `_shtNumberSpoke`. This guarantees the division will be floating-point and will retain any fractional part. Only line 378 in `sqlnexus/Spinner.cs` needs to be changed: cast `NUMBER_OF_DEGREES_CIRCLE` to `double` during the division calculation. No new methods or imports are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
