### PR TITLE
Potential fix for code scanning alert no. 442: Potentially dangerous use of non-short-circuit logic

### DIFF
--- a/sqlnexus/fmImport.cs
+++ b/sqlnexus/fmImport.cs
@@ -1225,12 +1225,12 @@ namespace sqlnexus
             process.BeginOutputReadLine();
             process.WaitForExit();
 
-            if ((error_stream != null) & (error_stream.Length != 0 ))
+            if ((error_stream != null) && (error_stream.Length != 0 ))
             {
                 MainForm.LogMessage("PostProcess error output: " + error_stream.ToString());
             }
 
-            if ((output_stream != null) & (output_stream.Length != 0 ))
+            if ((output_stream != null) && (output_stream.Length != 0 ))
             {
                 MainForm.LogMessage("PostProcess console output: " + output_stream.ToString().Replace("+++", "\r\n\t"));
             }


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/SqlNexus/security/code-scanning/442](https://github.com/microsoft/SqlNexus/security/code-scanning/442)

The safest and clearest way to fix this is to replace the non-short-circuit AND (`&`) with the short-circuit AND (`&&`) in the conditional expressions at lines 1228 and 1233. This ensures that if `error_stream` or `output_stream` is `null`, their `.Length` properties are not accessed, preventing any `NullReferenceException` at runtime. The existing logic and functionality remain the same; only the use of the operator is updated for correctness and clarity.

No new imports, methods, or other structural changes are necessary. The required change is wholly contained within lines 1228 and 1233 in file `sqlnexus/fmImport.cs`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
