### PR TITLE
Fix broken links to ReadTrace reports since file names have been changed

### DIFF
--- a/NexusReports/NexusReports.rptproj
+++ b/NexusReports/NexusReports.rptproj
@@ -82,6 +82,15 @@
     <Report Include="Query Hash_C.rdl" />
     <Report Include="Query_Store_C.rdl" />
     <Report Include="Query_Store_Details_C.rdl" />
+    <Report Include="ReadTrace_Grouping_C.rdl" />
+    <Report Include="ReadTrace_InterestingEvents_C.rdl" />
+    <Report Include="ReadTrace_Lineage_C.rdl" />
+    <Report Include="ReadTrace_Main_C.rdl" />
+    <Report Include="ReadTrace_UniqueBatchDetails_C.rdl" />
+    <Report Include="ReadTrace_UniqueBatchTopN_C.rdl" />
+    <Report Include="ReadTrace_UniqueStmtDetails_C.rdl" />
+    <Report Include="ReadTrace_UniqueStmtTopN_C.rdl" />
+    <Report Include="ReadTrace_Warnings_C.rdl" />
     <Report Include="Replication_Topology_C.rdl" />
     <Report Include="Running_Device_Drivers_C.rdl" />
     <Report Include="ServerConfiguration_C.rdl" />

--- a/NexusReports/ReadTrace_Grouping_C.rdl
+++ b/NexusReports/ReadTrace_Grouping_C.rdl
@@ -968,7 +968,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -1326,7 +1326,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -1405,7 +1405,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -1484,7 +1484,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -2211,7 +2211,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -2593,7 +2593,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -2672,7 +2672,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -2751,7 +2751,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -3502,7 +3502,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>

--- a/NexusReports/ReadTrace_InterestingEvents_C.rdl
+++ b/NexusReports/ReadTrace_InterestingEvents_C.rdl
@@ -1348,7 +1348,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_InterestingEvents</ReportName>
+                                  <ReportName>ReadTrace_InterestingEvents_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -1778,7 +1778,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_InterestingEvents</ReportName>
+                                  <ReportName>ReadTrace_InterestingEvents_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -3494,7 +3494,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                 <Actions>
                                   <Action>
                                     <Drillthrough>
-                                      <ReportName>ReadTrace_UniqueBatchDetails</ReportName>
+                                      <ReportName>ReadTrace_UniqueBatchDetails_C</ReportName>
                                       <Parameters>
                                         <Parameter Name="dsServerName">
                                           <Value>=Parameters!dsServerName.Value</Value>
@@ -3746,7 +3746,7 @@ Parameters!ContrastTheme.Value="None", "Gainsboro")</BackgroundColor>
                                 <Actions>
                                   <Action>
                                     <Drillthrough>
-                                      <ReportName>ReadTrace_UniqueStmtDetails</ReportName>
+                                      <ReportName>ReadTrace_UniqueStmtDetails_C</ReportName>
                                       <Parameters>
                                         <Parameter Name="dsServerName">
                                           <Value>=Parameters!dsServerName.Value</Value>

--- a/NexusReports/ReadTrace_Main_C.rdl
+++ b/NexusReports/ReadTrace_Main_C.rdl
@@ -1757,7 +1757,7 @@ Parameters!ContrastTheme.Value="None", "Navy")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -4955,7 +4955,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Grouping</ReportName>
+                    <ReportName>ReadTrace_Grouping_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5019,7 +5019,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Grouping</ReportName>
+                    <ReportName>ReadTrace_Grouping_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5083,7 +5083,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Grouping</ReportName>
+                    <ReportName>ReadTrace_Grouping_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5183,7 +5183,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Lineage</ReportName>
+                    <ReportName>ReadTrace_Lineage_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5238,7 +5238,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_InterestingEvents</ReportName>
+                    <ReportName>ReadTrace_InterestingEvents_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5303,7 +5303,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                    <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5367,7 +5367,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_UniqueStmtTopN</ReportName>
+                    <ReportName>ReadTrace_UniqueStmtTopN_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5471,7 +5471,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Warnings</ReportName>
+                    <ReportName>ReadTrace_Warnings_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>

--- a/NexusReports/ReadTrace_UniqueBatchDetails_C.rdl
+++ b/NexusReports/ReadTrace_UniqueBatchDetails_C.rdl
@@ -7501,7 +7501,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                 <Actions>
                                   <Action>
                                     <Drillthrough>
-                                      <ReportName>ReadTrace_UniqueStmtDetails</ReportName>
+                                      <ReportName>ReadTrace_UniqueStmtDetails_C</ReportName>
                                       <Parameters>
                                         <Parameter Name="dsServerName">
                                           <Value>=Parameters!dsServerName.Value</Value>

--- a/NexusReports/ReadTrace_UniqueBatchTopN_C.rdl
+++ b/NexusReports/ReadTrace_UniqueBatchTopN_C.rdl
@@ -1485,7 +1485,7 @@ Parameters!ContrastTheme.Value="None", "DarkBlue")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchDetails</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchDetails_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>

--- a/NexusReports/ReadTrace_UniqueStmtTopN_C.rdl
+++ b/NexusReports/ReadTrace_UniqueStmtTopN_C.rdl
@@ -1377,7 +1377,7 @@
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueStmtDetails</ReportName>
+                                  <ReportName>ReadTrace_UniqueStmtDetails_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>

--- a/sqlnexus/Reports/ReadTrace_Grouping_C.rdlC
+++ b/sqlnexus/Reports/ReadTrace_Grouping_C.rdlC
@@ -968,7 +968,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -1326,7 +1326,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -1405,7 +1405,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -1484,7 +1484,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -2211,7 +2211,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -2593,7 +2593,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -2672,7 +2672,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -2751,7 +2751,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                           <Actions>
                                             <Action>
                                               <Drillthrough>
-                                                <ReportName>ReadTrace_Grouping</ReportName>
+                                                <ReportName>ReadTrace_Grouping_C</ReportName>
                                                 <Parameters>
                                                   <Parameter Name="dsServerName">
                                                     <Value>=Parameters!dsServerName.Value</Value>
@@ -3502,7 +3502,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>

--- a/sqlnexus/Reports/ReadTrace_InterestingEvents_C.rdlC
+++ b/sqlnexus/Reports/ReadTrace_InterestingEvents_C.rdlC
@@ -1348,7 +1348,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_InterestingEvents</ReportName>
+                                  <ReportName>ReadTrace_InterestingEvents_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -1778,7 +1778,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_InterestingEvents</ReportName>
+                                  <ReportName>ReadTrace_InterestingEvents_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -3494,7 +3494,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                 <Actions>
                                   <Action>
                                     <Drillthrough>
-                                      <ReportName>ReadTrace_UniqueBatchDetails</ReportName>
+                                      <ReportName>ReadTrace_UniqueBatchDetails_C</ReportName>
                                       <Parameters>
                                         <Parameter Name="dsServerName">
                                           <Value>=Parameters!dsServerName.Value</Value>
@@ -3746,7 +3746,7 @@ Parameters!ContrastTheme.Value="None", "Gainsboro")</BackgroundColor>
                                 <Actions>
                                   <Action>
                                     <Drillthrough>
-                                      <ReportName>ReadTrace_UniqueStmtDetails</ReportName>
+                                      <ReportName>ReadTrace_UniqueStmtDetails_C</ReportName>
                                       <Parameters>
                                         <Parameter Name="dsServerName">
                                           <Value>=Parameters!dsServerName.Value</Value>

--- a/sqlnexus/Reports/ReadTrace_Main_C.rdlC
+++ b/sqlnexus/Reports/ReadTrace_Main_C.rdlC
@@ -1757,7 +1757,7 @@ Parameters!ContrastTheme.Value="None", "Navy")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>
@@ -4955,7 +4955,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Grouping</ReportName>
+                    <ReportName>ReadTrace_Grouping_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5019,7 +5019,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Grouping</ReportName>
+                    <ReportName>ReadTrace_Grouping_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5083,7 +5083,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Grouping</ReportName>
+                    <ReportName>ReadTrace_Grouping_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5183,7 +5183,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Lineage</ReportName>
+                    <ReportName>ReadTrace_Lineage_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5238,7 +5238,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_InterestingEvents</ReportName>
+                    <ReportName>ReadTrace_InterestingEvents_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5303,7 +5303,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_UniqueBatchTopN</ReportName>
+                    <ReportName>ReadTrace_UniqueBatchTopN_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5367,7 +5367,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_UniqueStmtTopN</ReportName>
+                    <ReportName>ReadTrace_UniqueStmtTopN_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>
@@ -5471,7 +5471,7 @@ Parameters!ContrastTheme.Value="None", "Blue")</Color>
               <Actions>
                 <Action>
                   <Drillthrough>
-                    <ReportName>ReadTrace_Warnings</ReportName>
+                    <ReportName>ReadTrace_Warnings_C</ReportName>
                     <Parameters>
                       <Parameter Name="dsServerName">
                         <Value>=Parameters!dsServerName.Value</Value>

--- a/sqlnexus/Reports/ReadTrace_UniqueBatchDetails_C.rdlC
+++ b/sqlnexus/Reports/ReadTrace_UniqueBatchDetails_C.rdlC
@@ -7501,7 +7501,7 @@ Parameters!ContrastTheme.Value="None", "Black")</Color>
                                 <Actions>
                                   <Action>
                                     <Drillthrough>
-                                      <ReportName>ReadTrace_UniqueStmtDetails</ReportName>
+                                      <ReportName>ReadTrace_UniqueStmtDetails_C</ReportName>
                                       <Parameters>
                                         <Parameter Name="dsServerName">
                                           <Value>=Parameters!dsServerName.Value</Value>

--- a/sqlnexus/Reports/ReadTrace_UniqueBatchTopN_C.rdlC
+++ b/sqlnexus/Reports/ReadTrace_UniqueBatchTopN_C.rdlC
@@ -1485,7 +1485,7 @@ Parameters!ContrastTheme.Value="None", "DarkBlue")</Color>
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueBatchDetails</ReportName>
+                                  <ReportName>ReadTrace_UniqueBatchDetails_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>

--- a/sqlnexus/Reports/ReadTrace_UniqueStmtTopN_C.rdlC
+++ b/sqlnexus/Reports/ReadTrace_UniqueStmtTopN_C.rdlC
@@ -1377,7 +1377,7 @@
                             <Actions>
                               <Action>
                                 <Drillthrough>
-                                  <ReportName>ReadTrace_UniqueStmtDetails</ReportName>
+                                  <ReportName>ReadTrace_UniqueStmtDetails_C</ReportName>
                                   <Parameters>
                                     <Parameter Name="dsServerName">
                                       <Value>=Parameters!dsServerName.Value</Value>

--- a/sqlnexus/sqlnexus.csproj
+++ b/sqlnexus/sqlnexus.csproj
@@ -610,6 +610,9 @@
     <Content Include="Reports\ActiveProcesses_C.rdlC">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Reports\ReadTrace_Main_C.rdlC">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Reports\ReadTrace_Grouping_C.rdlC">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -617,9 +620,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Reports\ReadTrace_Lineage_C.rdlC">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="Reports\ReadTrace_Main_C.rdlC">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="Reports\ReadTrace_UniqueBatchDetails_C.rdlC">


### PR DESCRIPTION
To test:
1. Open a ReadTrace report 
2. Test all links to other reports inside all reports (not too many)