### PR TITLE
Add SQLDiagAlwaysOnXEL import menu option to exclude SQLDiag/AlwaysON/System Health XEL from default import

### DIFF
--- a/sqlnexus/CustomXELImporter.cs
+++ b/sqlnexus/CustomXELImporter.cs
@@ -27,7 +27,9 @@ namespace sqlnexus
         int countTotalFilesFound = 0;
         int totalRowsAffected = 0;
 
-        public string SQLBaseImport(string connString, string Server, bool UseWindowsAuth, string SQLLogin, string SQLPassword, string DatabaseName, string srcpath)
+        bool dropExistingTables = true;
+
+        public string SQLBaseImport(string connString, string Server, bool UseWindowsAuth, string SQLLogin, string SQLPassword, string DatabaseName, string srcpath, bool importSQLDiagAlwaysOnXEL = true, bool dropTables = true)
         {
 
             connStr = connString;
@@ -37,19 +39,30 @@ namespace sqlnexus
             sqlpassword = SQLPassword;
             databasename = DatabaseName;
             srcPath = srcpath;
+            dropExistingTables = dropTables;
 
 
-            int sqlDiagRowsImported = LoadSQLDiaglFiles();
-            int alwaysOnRowsImported = LoadAlwaysonHealthFiles();
-            int systemHealthRowsImported = LoadSystemHealthFiles();
+            int sqlDiagRowsImported = 0;
+            int alwaysOnRowsImported = 0;
+            if (importSQLDiagAlwaysOnXEL)
+            {
+                sqlDiagRowsImported = LoadSQLDiaglFiles();
+                alwaysOnRowsImported = LoadAlwaysonHealthFiles();
+                int systemHealthRowsImported = LoadSystemHealthFiles();
 
-            string retStr = String.Format("{0} rows imported (SqlDiag {2}, AOHealth {3}, SysHealth {4}) across {1} XEL files.", 
-                                totalRowsAffected, 
-                                countTotalFilesFound,
-                                sqlDiagRowsImported,
-                                alwaysOnRowsImported,
-                                systemHealthRowsImported);
-            return retStr;
+                string retStr = String.Format("{0} rows imported (SqlDiag {2}, AOHealth {3}, SysHealth {4}) across {1} XEL files.", 
+                                    totalRowsAffected, 
+                                    countTotalFilesFound,
+                                    sqlDiagRowsImported,
+                                    alwaysOnRowsImported,
+                                    systemHealthRowsImported);
+                return retStr;
+            }
+            else
+            {
+                Util.Logger.LogMessage("Skipping SQLDiag and AlwaysOn XEL import (SQLDiagAlwaysOnXEL option is disabled).");
+                return "Skipped (disabled)";
+            }
 
 
         }
@@ -83,11 +96,12 @@ namespace sqlnexus
                     if (index > 0)
                         XEFile = XEFile.Substring(0, index);
 
-                    string sqlstatment = @"IF OBJECT_ID(N'tbl_SQL_Base_SQLDIAGXEL_Startup', N'U') IS NOT NULL
+                    string dropSql = dropExistingTables ? @"IF OBJECT_ID(N'tbl_SQL_Base_SQLDIAGXEL_Startup', N'U') IS NOT NULL
                             BEGIN
                             DROP TABLE tbl_SQL_Base_SQLDIAGXEL_Startup;
                             END
-                            SELECT * INTO tbl_SQL_Base_SQLDIAGXEL_Startup FROM sys.fn_xe_file_target_read_file('" + XEFile + "*.XEL', NULL, null, null);";
+                            " : "";
+                    string sqlstatment = dropSql + "SELECT * INTO tbl_SQL_Base_SQLDIAGXEL_Startup FROM sys.fn_xe_file_target_read_file('" + XEFile + "*.XEL', NULL, null, null);";
 
 
 
@@ -141,11 +155,12 @@ namespace sqlnexus
                     if (index > 0)
                         XEFile = XEFile.Substring(0, index);
 
-                    string sqlstatment = @"IF OBJECT_ID(N'tbl_SQL_Base_AlwaysOnHealth', N'U') IS NOT NULL
+                    string dropSql = dropExistingTables ? @"IF OBJECT_ID(N'tbl_SQL_Base_AlwaysOnHealth', N'U') IS NOT NULL
                              BEGIN
                             DROP TABLE tbl_SQL_Base_AlwaysOnHealth;
                                 END
-                            SELECT * INTO tbl_SQL_Base_AlwaysOnHealth FROM sys.fn_xe_file_target_read_file('" + XEFile + "*.XEL', NULL, null, null);";
+                            " : "";
+                    string sqlstatment = dropSql + "SELECT * INTO tbl_SQL_Base_AlwaysOnHealth FROM sys.fn_xe_file_target_read_file('" + XEFile + "*.XEL', NULL, null, null);";
                     SqlCommand cmd = new SqlCommand(sqlstatment, cnn);
                     cmd.CommandTimeout = 0;
                     totalRowsAffected += AlwaysOnRowsImported = cmd.ExecuteNonQuery();
@@ -195,11 +210,12 @@ namespace sqlnexus
                     int index = XEFile.IndexOf("system_health");
                     if (index > 0)
                         XEFile = XEFile.Substring(0, index);
-                    string sqlstatment = @" IF OBJECT_ID(N'tbl_SQL_Base_SystemHealthXEL_Startup', N'U') IS NOT NULL
+                    string dropSql = dropExistingTables ? @"IF OBJECT_ID(N'tbl_SQL_Base_SystemHealthXEL_Startup', N'U') IS NOT NULL
                             BEGIN
                             DROP TABLE tbl_SQL_Base_SystemHealthXEL_Startup;
                             END
-                            SELECT * INTO tbl_SQL_Base_SystemHealthXEL_Startup FROM sys.fn_xe_file_target_read_file('" + XEFile + "*.XEL', NULL, null, null);";
+                            " : "";
+                    string sqlstatment = dropSql + "SELECT * INTO tbl_SQL_Base_SystemHealthXEL_Startup FROM sys.fn_xe_file_target_read_file('" + XEFile + "*.XEL', NULL, null, null);";
 
 
 

--- a/sqlnexus/fmImport.Designer.cs
+++ b/sqlnexus/fmImport.Designer.cs
@@ -35,6 +35,7 @@ namespace sqlnexus
             this.cmOptions = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.tsiImporters = new System.Windows.Forms.ToolStripMenuItem();
             this.tsiDropDBBeforeImporting = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsiSQLDiagAlwaysOnXEL = new System.Windows.Forms.ToolStripMenuItem();
             this.tsiSaveOptions = new System.Windows.Forms.ToolStripMenuItem();
             this.tsiUseDefaultOptions = new System.Windows.Forms.ToolStripMenuItem();
             this.btnClose = new System.Windows.Forms.Button();
@@ -323,6 +324,7 @@ namespace sqlnexus
         private System.Windows.Forms.ToolStripMenuItem tsiSaveOptions;
         private System.Windows.Forms.ToolStripMenuItem tsiUseDefaultOptions;
         private System.Windows.Forms.ToolStripMenuItem tsiDropDBBeforeImporting;
+        private System.Windows.Forms.ToolStripMenuItem tsiSQLDiagAlwaysOnXEL;
         private System.Windows.Forms.Button btnClose;
     }
 }

--- a/sqlnexus/fmImport.cs
+++ b/sqlnexus/fmImport.cs
@@ -608,6 +608,13 @@ namespace sqlnexus
 
                             tsi.DropDownItems.Add(subtsi);
                         }
+
+                        // Keep submenu open when toggling checkbox options (mouse click or keyboard Enter/Space)
+                        tsi.DropDown.Closing += (s, ev) =>
+                        {
+                            if (ev.CloseReason == ToolStripDropDownCloseReason.ItemClicked)
+                                ev.Cancel = true;
+                        };
                     }
                 }
             }
@@ -645,6 +652,14 @@ namespace sqlnexus
 
             tsiSQLDiagAlwaysOnXEL.DropDownItems.Add(tsiSQLDiagAlwaysOnXEL_DropTables);
             tsiSQLDiagAlwaysOnXEL.DropDownItems.Add(tsiSQLDiagAlwaysOnXEL_Enabled);
+
+            // Keep submenu open when toggling checkbox options (mouse click or keyboard Enter/Space)
+            tsiSQLDiagAlwaysOnXEL.DropDown.Closing += (s, ev) =>
+            {
+                if (ev.CloseReason == ToolStripDropDownCloseReason.ItemClicked)
+                    ev.Cancel = true;
+            };
+
             tsiImporters.DropDownItems.Add(tsiSQLDiagAlwaysOnXEL);
         }
 
@@ -1543,7 +1558,10 @@ namespace sqlnexus
                         {
                             foreach (ToolStripMenuItem tsi_IndividualOptionMenu in tsi_ProductMenu.DropDownItems)
                             {
-                                INexusImporter prod = (INexusImporter)tsi_IndividualOptionMenu.Tag;
+                                INexusImporter prod = tsi_IndividualOptionMenu.Tag as INexusImporter;
+                                // Skip menu items not backed by an INexusImporter (e.g. custom SQLDiag/AlwaysOn XEL sub-items)
+                                if (prod == null)
+                                    continue;
                                 String OptionName = String.Format("{0}.{1}", prod.Name, tsi_IndividualOptionMenu.Text);
                                 ImportOptions.Set(OptionName, tsi_IndividualOptionMenu.Checked);
 

--- a/sqlnexus/fmImport.cs
+++ b/sqlnexus/fmImport.cs
@@ -19,6 +19,8 @@ namespace sqlnexus
     public partial class fmImport : Form
     {
         private List<ToolStripMenuItem> m_OptionList = new List<ToolStripMenuItem>();
+        private ToolStripMenuItem tsiSQLDiagAlwaysOnXEL_Enabled;
+        private ToolStripMenuItem tsiSQLDiagAlwaysOnXEL_DropTables;
         private SqlInstances instances;
         private fmImport()
         {
@@ -609,6 +611,41 @@ namespace sqlnexus
                     }
                 }
             }
+
+            // Add the SQLDiag/AlwaysOn XEL option under Importers with sub-items
+            tsiSQLDiagAlwaysOnXEL.Name = "tsiSQLDiagAlwaysOnXEL";
+            tsiSQLDiagAlwaysOnXEL.Text = "Import SQLDiag/AlwaysOn XEL";
+            tsiSQLDiagAlwaysOnXEL.AccessibleName = "Import SQLDiag AlwaysOn XEL";
+            tsiSQLDiagAlwaysOnXEL.AccessibleDescription = "Submenu for importing SQLDiag and AlwaysOn Extended Events XEL files";
+            tsiSQLDiagAlwaysOnXEL.DropDownItems.Clear();
+
+            // "Drop existing tables" sub-item
+            tsiSQLDiagAlwaysOnXEL_DropTables = new ToolStripMenuItem("Drop existing tables");
+            tsiSQLDiagAlwaysOnXEL_DropTables.Name = "tsiSQLDiagAlwaysOnXEL_DropTables";
+            tsiSQLDiagAlwaysOnXEL_DropTables.CheckOnClick = true;
+            tsiSQLDiagAlwaysOnXEL_DropTables.Checked = true;
+            tsiSQLDiagAlwaysOnXEL_DropTables.AccessibleName = "Drop existing tables";
+            tsiSQLDiagAlwaysOnXEL_DropTables.AccessibleDescription = "When checked, existing SQLDiag and AlwaysOn XEL tables are dropped before import";
+            tsiSQLDiagAlwaysOnXEL_DropTables.Click += new EventHandler(tsiSQLDiagAlwaysOnXEL_SubOption_Click);
+
+            // "Enabled" sub-item
+            tsiSQLDiagAlwaysOnXEL_Enabled = new ToolStripMenuItem("Enabled");
+            tsiSQLDiagAlwaysOnXEL_Enabled.Name = "tsiSQLDiagAlwaysOnXEL_Enabled";
+            tsiSQLDiagAlwaysOnXEL_Enabled.CheckOnClick = true;
+            tsiSQLDiagAlwaysOnXEL_Enabled.Checked = false;
+            tsiSQLDiagAlwaysOnXEL_Enabled.AccessibleName = "Enabled";
+            tsiSQLDiagAlwaysOnXEL_Enabled.AccessibleDescription = "When checked, SQLDiag and AlwaysOn XEL files are included in the import";
+            tsiSQLDiagAlwaysOnXEL_Enabled.Click += new EventHandler(tsiSQLDiagAlwaysOnXEL_SubOption_Click);
+
+            if (ImportOptions.IsEnabled("SaveImportOptions"))
+            {
+                tsiSQLDiagAlwaysOnXEL_Enabled.Checked = ImportOptions.IsEnabled("SQLDiagAlwaysOnXEL.Enabled");
+                tsiSQLDiagAlwaysOnXEL_DropTables.Checked = ImportOptions.IsEnabled("SQLDiagAlwaysOnXEL.DropExistingTables");
+            }
+
+            tsiSQLDiagAlwaysOnXEL.DropDownItems.Add(tsiSQLDiagAlwaysOnXEL_DropTables);
+            tsiSQLDiagAlwaysOnXEL.DropDownItems.Add(tsiSQLDiagAlwaysOnXEL_Enabled);
+            tsiImporters.DropDownItems.Add(tsiSQLDiagAlwaysOnXEL);
         }
 
 
@@ -636,6 +673,9 @@ namespace sqlnexus
             foreach (ToolStripMenuItem tsi in tsiImporters.DropDownItems)
             {
                 prod = (tsi.Tag as INexusImporter);
+                // Skip menu items that are not backed by an INexusImporter (e.g. the custom SQLDiag/AlwaysOn XEL menu item)
+                if (prod == null)
+                    continue;
                 // See whether this importer is enabled (each importer should have an "Enabled" option)
                 bool Enabled = true;
                 foreach (ToolStripMenuItem tsi2 in tsi.DropDownItems)
@@ -872,7 +912,10 @@ namespace sqlnexus
 
             //add individual rows for each of these so they show up as progress bars in the summary window listview
             string customXELImprtStr = "CustomXELImporter";
-            AddFileRow((tlpFiles.RowCount - 1), "Custom XEL import (SQLDiag, AlwaysOnHealth, System Health)", null, customXELImprtStr);
+            if (tsiSQLDiagAlwaysOnXEL_Enabled != null && tsiSQLDiagAlwaysOnXEL_Enabled.Checked)
+            {
+                AddFileRow((tlpFiles.RowCount - 1), "Custom XEL import (SQLDiag, AlwaysOnHealth, System Health)", null, customXELImprtStr);
+            }
 
             string rawFileImprtStr = "RawFileImport";
             AddFileRow((tlpFiles.RowCount - 1), "Raw file import", null, rawFileImprtStr);
@@ -1035,7 +1078,9 @@ namespace sqlnexus
                                                                 Globals.credentialMgr.WindowsAuth,
                                                                 Globals.credentialMgr.User,
                                                                 Globals.credentialMgr.Password,
-                                                                Globals.credentialMgr.Database, srcPath);
+                                                                Globals.credentialMgr.Database, srcPath,
+                                                                tsiSQLDiagAlwaysOnXEL_Enabled.Checked,
+                                                                tsiSQLDiagAlwaysOnXEL_DropTables.Checked);
                         
 
                         currBar.Value = 100;
@@ -1507,6 +1552,8 @@ namespace sqlnexus
                 }
 
                 ImportOptions.Set("DropDbBeforeImporting", tsiDropDBBeforeImporting.Checked);
+                ImportOptions.Set("SQLDiagAlwaysOnXEL.Enabled", tsiSQLDiagAlwaysOnXEL_Enabled.Checked);
+                ImportOptions.Set("SQLDiagAlwaysOnXEL.DropExistingTables", tsiSQLDiagAlwaysOnXEL_DropTables.Checked);
             }
             else
                 ImportOptions.Clear();
@@ -1563,6 +1610,14 @@ namespace sqlnexus
 
 
         }
+        private void tsiSQLDiagAlwaysOnXEL_SubOption_Click(object sender, EventArgs e)
+        {
+            if (ImportOptions.IsEnabled("SaveImportOptions"))
+            {
+                ImportOptions.Set("SQLDiagAlwaysOnXEL.Enabled", tsiSQLDiagAlwaysOnXEL_Enabled.Checked);
+                ImportOptions.Set("SQLDiagAlwaysOnXEL.DropExistingTables", tsiSQLDiagAlwaysOnXEL_DropTables.Checked);
+            }
+        }
         private void cmOptions_Opening(object sender, CancelEventArgs e)
         {
             tsiSaveOptions.Click += new EventHandler(tsiSaveOptions_Click);
@@ -1570,7 +1625,9 @@ namespace sqlnexus
             tsiDropDBBeforeImporting.CheckedChanged += new EventHandler(tsiDropDBBeforeImporting_Click);
             tsiSaveOptions.Checked = ImportOptions.IsEnabled("SaveImportOptions");
             if (ImportOptions.IsEnabled("SaveImportOptions"))
+            {
                 tsiDropDBBeforeImporting.Checked = ImportOptions.IsEnabled("DropDbBeforeImporting");
+            }
 
         }
 

--- a/sqlnexus/fmImport.cs
+++ b/sqlnexus/fmImport.cs
@@ -1074,13 +1074,15 @@ namespace sqlnexus
 
                         // do the custom XEL import - system health, Always ON, etc.
                         CustomXELImporter CI = new CustomXELImporter();
+                        bool alwaysOnXelEnabled = tsiSQLDiagAlwaysOnXEL_Enabled != null && tsiSQLDiagAlwaysOnXEL_Enabled.Checked;
+                        bool alwaysOnXelDropTables = tsiSQLDiagAlwaysOnXEL_DropTables != null && tsiSQLDiagAlwaysOnXEL_DropTables.Checked;
                         string XelImprtStatusStr = CI.SQLBaseImport(Globals.credentialMgr.ConnectionString, Globals.credentialMgr.Server,
                                                                 Globals.credentialMgr.WindowsAuth,
                                                                 Globals.credentialMgr.User,
                                                                 Globals.credentialMgr.Password,
                                                                 Globals.credentialMgr.Database, srcPath,
-                                                                tsiSQLDiagAlwaysOnXEL_Enabled.Checked,
-                                                                tsiSQLDiagAlwaysOnXEL_DropTables.Checked);
+                                                                alwaysOnXelEnabled,
+                                                                alwaysOnXelDropTables);
                         
 
                         currBar.Value = 100;


### PR DESCRIPTION
- Add "Import SQLDiag/AlwaysOn XEL" menu under Importers with "Enabled" (off by default) and "Drop existing tables" sub-items
- Gate all three XEL imports (SQLDiag, AlwaysOn, System Health) behind the Enabled option
- Hide progress bar row when the option is disabled
- Add null check in EnumFiles() for non-INexusImporter menu items
- Wire save/restore/reset of new options through ImportOptions
- Add accessibility properties (AccessibleName, AccessibleDescription) to new menu items

<img width="919" height="321" alt="image" src="https://github.com/user-attachments/assets/9f33d763-e507-485a-95e2-94ab0c560049" />


## Test scenarios

### Test 1: Default behavior — XEL import is skipped
1.	Open SQL Nexus, open the Data Import dialog
2.	Set the source path to your test folder
3.	Click Options → Importers → verify Import SQLDiag/AlwaysOn XEL submenu exists
4.	Confirm Enabled is unchecked by default
5.	Click Import
6.	Expected: No "Custom XEL import" progress bar row appears. No tbl_SQL_Base_SQLDIAGXEL_Startup, tbl_SQL_Base_AlwaysOnHealth, or tbl_SQL_Base_SystemHealthXEL_Startup tables are created in the database. All other importers run normally.

### Test 2: Enable the option — XEL import runs
1.	Click Options → Importers → Import SQLDiag/AlwaysOn XEL → check Enabled
2.	Verify Drop existing tables is checked by default
3.	Click Import
4.	Expected: "Custom XEL import (SQLDiag, AlwaysOnHealth, System Health)" progress bar row appears and completes. The three tbl_SQL_Base_* tables are created with data. Status label shows row counts (e.g. SqlDiag 0, AOHealth 0, SysHealth 65137).


### Test 3: Drop existing tables unchecked — second import appends/fails gracefully
1.	With tables from Test 2 still in the database, uncheck Drop existing tables
2.	Keep Enabled checked
3.	Click Import
4.	Expected: Import attempts SELECT * INTO without dropping first. If tables already exist, the import should error gracefully (logged in status label) — tables are not silently dropped.

### Test 4: Drop existing tables checked — re-import succeeds
1.	Check both Drop existing tables and Enabled
2.	Click Import
3.	Expected: Existing tbl_SQL_Base_* tables are dropped and recreated. Import completes with row counts displayed.

### Test 5: Save/restore options
1.	Check Save My Options in the Options menu
2.	Enable Import SQLDiag/AlwaysOn XEL → Enabled, uncheck Drop existing tables
3.	Close and reopen the Data Import dialog
4.	Expected: Enabled remains checked, Drop existing tables remains unchecked

### Test 6: Restore Default Options
1.	Click Options → Restore Default Options
2.	Open Importers → Import SQLDiag/AlwaysOn XEL
3.	Expected: Enabled is unchecked, Drop existing tables is checked (defaults)


### Test 8: Keyboard accessibility
1.	Open Options menu using keyboard
2.	Use arrow keys to navigate to Importers → Import SQLDiag/AlwaysOn XEL → sub-items
3.	Use Space or Enter to toggle checkboxes
4.	Expected: All items are navigable and toggleable via keyboard. No items are skipped or unreachable.

### Test 9: Other importers unaffected
1.	With Enabled unchecked, verify all other importers (Rowset Importer, ReadTrace, BLG Blaster, Linux Perf) function normally
2.	Expected: No regressions in any other import pathway.
