### PR TITLE
CFS compliance: route NuGet restore through Azure Artifacts feed

### DIFF
--- a/Pipeline/azure-pipeline.yml
+++ b/Pipeline/azure-pipeline.yml
@@ -49,13 +49,16 @@ extends:
         steps:
         - checkout: self
 
-        # NuGet restore
+        # NuGet restore (CFS compliant)
         - task: NuGetToolInstaller@1
+        - task: NuGetAuthenticate@1
+
         - task: NuGetCommand@2
           inputs:
             command: restore
             restoreSolution: '$(Build.SourcesDirectory)/sqlnexus.sln'
-            feedsToUse: select
+            feedsToUse: config
+            nugetConfigPath: '$(Build.SourcesDirectory)/nuget.config'
 
         # Build the solution
         - task: VSBuild@1

--- a/Pipeline/azure-pipeline.yml
+++ b/Pipeline/azure-pipeline.yml
@@ -34,6 +34,8 @@ extends:
       name: ${{ parameters.poolName }}
       image: ${{ parameters.image }}
       os: ${{ parameters.os }}
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
 
     stages:
     - stage: BuildAndScan

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,8 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Guardian1ESPTUpstreamOrgFeed" 
-         value="https://mssql-support.pkgs.visualstudio.com/_packaging/Guardian1ESPTUpstreamOrgFeed/nuget/v3/index.json" />
+    <add key="Guardian1ESPTUpstreamOrgFeed" value="https://mssql-support.pkgs.visualstudio.com/_packaging/Guardian1ESPTUpstreamOrgFeed/nuget/v3/index.json" />
+    <add key="Mssql-Suppot-Feed" value="https://mssql-support.pkgs.visualstudio.com/SQLNexus-ADO/_packaging/Mssql-Suppot-Feed/nuget/v3/index.json" />
   </packageSources>
 </configuration>
+

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,7 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Guardian1ESPTUpstreamOrgFeed"
-         value="https://pkgs.dev.azure.com/mssql-support/_packaging/Guardian1ESPTUpstreamOrgFeed/nuget/v3/index.json" />
+    <add key="Guardian1ESPTUpstreamOrgFeed" 
+         value="https://mssql-support.pkgs.visualstudio.com/_packaging/Guardian1ESPTUpstreamOrgFeed/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="Guardian1ESPTUpstreamOrgFeed"
+         value="https://pkgs.dev.azure.com/mssql-support/_packaging/Guardian1ESPTUpstreamOrgFeed/nuget/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="Guardian1ESPTUpstreamOrgFeed" value="https://mssql-support.pkgs.visualstudio.com/_packaging/Guardian1ESPTUpstreamOrgFeed/nuget/v3/index.json" />
     <add key="Mssql-Suppot-Feed" value="https://mssql-support.pkgs.visualstudio.com/SQLNexus-ADO/_packaging/Mssql-Suppot-Feed/nuget/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION

- Added root nuget.config with Azure Artifacts feed
- Removed implicit usage of nuget.org by including <clear /> and single feed configuration
- Updated pipeline NuGet restore to use feedsToUse: config
- Added NuGetAuthenticate task to enable feed access