### PR TITLE
#529 - Fixing the rowset to properly import data from dm_exec_connections

### DIFF
--- a/RowsetImportEngine/TextRowsets.xml
+++ b/RowsetImportEngine/TextRowsets.xml
@@ -878,7 +878,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_DM_EXEC_CONNECTIONS" enabled="true" identifier="-- dm_exec_connections" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_dm_exec_connections" enabled="true" identifier="-- exec_connections --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="rownum" type="RowsetImportEngine.BigIntColumn" length="24" valuetoken="ROWNUMBER" />
         <Column name="runtime" type="RowsetImportEngine.DateTimeColumn" />


### PR DESCRIPTION
This pull request makes a minor change to the `RowsetImportEngine/TextRowsets.xml` file by updating the name and identifier of a rowset to follow a consistent naming convention.

- Changed the `Rowset` name from `tbl_DM_EXEC_CONNECTIONS` to `tbl_dm_exec_connections`, and updated the `identifier` from `"-- dm_exec_connections"` to `"-- exec_connections --"` for consistency.…ions

How to test?

Load data from Log Scout with any perf scenario. Observe the file perstats, specifically the file with tag -- exec_connections --.

Confirm the table [dbo].[tbl_dm_exec_connections] is created and populated with data from tag -- exec_connections --.

