### PR TITLE
Creating importers for the new SQL Log Scout Connectivity Related collector

### DIFF
--- a/RowsetImportEngine/TextRowsets.xml
+++ b/RowsetImportEngine/TextRowsets.xml
@@ -4849,7 +4849,7 @@
     <!-- the dashed separator line and matches the header names below.                                   -->
     <!-- ============================================================================================== -->
 
-    <Rowset name="tbl_TLS_SSL_Protocols" enabled="true" identifier="-- TLS_SSL_Protocols --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_tls_ssl_protocols" enabled="true" identifier="-- TLS_SSL_Protocols --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Protocol" type="RowsetImportEngine.VarCharColumn" length="30" />
         <Column name="Role" type="RowsetImportEngine.VarCharColumn" length="8" />
@@ -4861,7 +4861,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Client_Drivers" enabled="true" identifier="-- SQL_Client_Drivers --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_client_drivers" enabled="true" identifier="-- SQL_Client_Drivers --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Name" type="RowsetImportEngine.VarCharColumn" length="32" />
         <Column name="Type" type="RowsetImportEngine.VarCharColumn" length="8" />
@@ -4875,7 +4875,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_SPN_ServiceAccounts" enabled="true" identifier="-- SQL_SPN_ServiceAccounts --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_spn_service_accounts" enabled="true" identifier="-- SQL_SPN_ServiceAccounts --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="ServiceName" type="RowsetImportEngine.VarCharColumn" length="24" />
         <Column name="ServiceAccountName" type="RowsetImportEngine.VarCharColumn" length="34" />
@@ -4884,7 +4884,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_SPN_Registered" enabled="true" identifier="-- SQL_SPN_Registered --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_spn_registered" enabled="true" identifier="-- SQL_SPN_Registered --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="38" />
         <Column name="SPN" type="RowsetImportEngine.VarCharColumn" length="54" />
@@ -4893,7 +4893,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_SPN_Suggested" enabled="true" identifier="-- SQL_SPN_Suggested --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_spn_suggested" enabled="true" identifier="-- SQL_SPN_Suggested --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="20" />
         <Column name="SuggestedSPN" type="RowsetImportEngine.VarCharColumn" length="54" />
@@ -4902,7 +4902,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Service_Summary" enabled="true" identifier="-- SQL_Service_Summary --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_service_summary" enabled="true" identifier="-- SQL_Service_Summary --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="18" />
         <Column name="ServiceName" type="RowsetImportEngine.VarCharColumn" length="22" />
@@ -4912,7 +4912,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Service_Account_Delegation" enabled="true" identifier="-- SQL_Service_Account_Delegation --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_service_account_delegation" enabled="true" identifier="-- SQL_Service_Account_Delegation --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="24" />
         <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="28" />
@@ -4920,14 +4920,14 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_Kerberos_Local_Policy" enabled="true" identifier="-- Kerberos_Local_Policy --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_kerberos_local_policy" enabled="true" identifier="-- Kerberos_Local_Policy --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="28" />
         <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="256" />
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Instance_Network_Security" enabled="true" identifier="-- SQL_Instance_Network_Security --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_instance_network_security" enabled="true" identifier="-- SQL_Instance_Network_Security --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="18" />
         <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="24" />
@@ -4935,7 +4935,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Client_Aliases" enabled="true" identifier="-- SQL_Client_Aliases --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_client_aliases" enabled="true" identifier="-- SQL_Client_Aliases --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Alias" type="RowsetImportEngine.VarCharColumn" length="28" />
         <Column name="Architecture" type="RowsetImportEngine.VarCharColumn" length="14" />
@@ -4946,7 +4946,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Server_Certificates" enabled="true" identifier="-- SQL_Server_Certificates --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_server_certificates" enabled="true" identifier="-- SQL_Server_Certificates --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="CertID" type="RowsetImportEngine.VarCharColumn" length="7" />
         <Column name="Thumbprint" type="RowsetImportEngine.VarCharColumn" length="42" />
@@ -4965,7 +4965,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Server_Certificate_KeyAcl" enabled="true" identifier="-- SQL_Server_Certificate_KeyAcl --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_server_certificate_key_acl" enabled="true" identifier="-- SQL_Server_Certificate_KeyAcl --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="CertID" type="RowsetImportEngine.VarCharColumn" length="7" />
         <Column name="Thumbprint" type="RowsetImportEngine.VarCharColumn" length="42" />

--- a/RowsetImportEngine/TextRowsets.xml
+++ b/RowsetImportEngine/TextRowsets.xml
@@ -4842,5 +4842,138 @@
       </KnownColumns>
     </Rowset>  
     
+    <!-- ============================================================================================== -->
+    <!-- SQL LogScout connectivity & security collectors (TLS protocols, client drivers, SPNs, service   -->
+    <!-- accounts, client aliases, server certificates). One rowset per section emitted by each          -->
+    <!-- collector's .out file. Output is fixed-width sqlcmd-style; the engine derives column widths from -->
+    <!-- the dashed separator line and matches the header names below.                                   -->
+    <!-- ============================================================================================== -->
+
+    <Rowset name="tbl_TLS_SSL_Protocols" enabled="true" identifier="-- TLS_SSL_Protocols --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Protocol" type="RowsetImportEngine.VarCharColumn" length="30" />
+        <Column name="Role" type="RowsetImportEngine.VarCharColumn" length="8" />
+        <Column name="RegEnabled" type="RowsetImportEngine.VarCharColumn" length="12" />
+        <Column name="RegDisabledByDefault" type="RowsetImportEngine.VarCharColumn" length="22" />
+        <Column name="EffectiveState" type="RowsetImportEngine.VarCharColumn" length="30" />
+        <Column name="Source" type="RowsetImportEngine.VarCharColumn" length="20" />
+        <Column name="RegistryPath" type="RowsetImportEngine.VarCharColumn" length="160" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Client_Drivers" enabled="true" identifier="-- SQL_Client_Drivers --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Name" type="RowsetImportEngine.VarCharColumn" length="32" />
+        <Column name="Type" type="RowsetImportEngine.VarCharColumn" length="8" />
+        <Column name="Version" type="RowsetImportEngine.VarCharColumn" length="18" />
+        <Column name="TLS12" type="RowsetImportEngine.VarCharColumn" length="9" />
+        <Column name="TLS13" type="RowsetImportEngine.VarCharColumn" length="9" />
+        <Column name="MSF" type="RowsetImportEngine.VarCharColumn" length="6" />
+        <Column name="Bitness" type="RowsetImportEngine.VarCharColumn" length="9" />
+        <Column name="CLSID" type="RowsetImportEngine.VarCharColumn" length="40" />
+        <Column name="Path" type="RowsetImportEngine.VarCharColumn" length="260" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_SPN_ServiceAccounts" enabled="true" identifier="-- SQL_SPN_ServiceAccounts --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="ServiceName" type="RowsetImportEngine.VarCharColumn" length="24" />
+        <Column name="ServiceAccountName" type="RowsetImportEngine.VarCharColumn" length="34" />
+        <Column name="SpnAccount" type="RowsetImportEngine.VarCharColumn" length="38" />
+        <Column name="State" type="RowsetImportEngine.VarCharColumn" length="16" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_SPN_Registered" enabled="true" identifier="-- SQL_SPN_Registered --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="38" />
+        <Column name="SPN" type="RowsetImportEngine.VarCharColumn" length="54" />
+        <Column name="Type" type="RowsetImportEngine.VarCharColumn" length="12" />
+        <Column name="Duplicate" type="RowsetImportEngine.VarCharColumn" length="10" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_SPN_Suggested" enabled="true" identifier="-- SQL_SPN_Suggested --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="20" />
+        <Column name="SuggestedSPN" type="RowsetImportEngine.VarCharColumn" length="54" />
+        <Column name="ExpectedAccount" type="RowsetImportEngine.VarCharColumn" length="24" />
+        <Column name="Status" type="RowsetImportEngine.VarCharColumn" length="64" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Service_Summary" enabled="true" identifier="-- SQL_Service_Summary --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="18" />
+        <Column name="ServiceName" type="RowsetImportEngine.VarCharColumn" length="22" />
+        <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="40" />
+        <Column name="StartMode" type="RowsetImportEngine.VarCharColumn" length="10" />
+        <Column name="State" type="RowsetImportEngine.VarCharColumn" length="16" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Service_Account_Delegation" enabled="true" identifier="-- SQL_Service_Account_Delegation --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="24" />
+        <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="28" />
+        <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="256" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_Kerberos_Local_Policy" enabled="true" identifier="-- Kerberos_Local_Policy --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="28" />
+        <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="256" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Instance_Network_Security" enabled="true" identifier="-- SQL_Instance_Network_Security --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="18" />
+        <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="24" />
+        <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="64" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Client_Aliases" enabled="true" identifier="-- SQL_Client_Aliases --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Alias" type="RowsetImportEngine.VarCharColumn" length="28" />
+        <Column name="Architecture" type="RowsetImportEngine.VarCharColumn" length="14" />
+        <Column name="Protocol" type="RowsetImportEngine.VarCharColumn" length="20" />
+        <Column name="Server" type="RowsetImportEngine.NVarCharColumn" length="48" />
+        <Column name="Port" type="RowsetImportEngine.VarCharColumn" length="8" />
+        <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="128" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Server_Certificates" enabled="true" identifier="-- SQL_Server_Certificates --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="CertID" type="RowsetImportEngine.VarCharColumn" length="7" />
+        <Column name="Thumbprint" type="RowsetImportEngine.VarCharColumn" length="42" />
+        <Column name="Subject" type="RowsetImportEngine.NVarCharColumn" length="40" />
+        <Column name="SubjectAltNames" type="RowsetImportEngine.NVarCharColumn" length="34" />
+        <Column name="ServerCert" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="NotBefore" type="RowsetImportEngine.DateTimeColumn" />
+        <Column name="NotAfter" type="RowsetImportEngine.DateTimeColumn" />
+        <Column name="Validity" type="RowsetImportEngine.VarCharColumn" length="13" />
+        <Column name="HasPrivKey" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="Exportable" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="KeyProv" type="RowsetImportEngine.VarCharColumn" length="9" />
+        <Column name="SqlAccess" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="SqlUsed" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="KeyContainerFile" type="RowsetImportEngine.NVarCharColumn" length="260" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Server_Certificate_KeyAcl" enabled="true" identifier="-- SQL_Server_Certificate_KeyAcl --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="CertID" type="RowsetImportEngine.VarCharColumn" length="7" />
+        <Column name="Thumbprint" type="RowsetImportEngine.VarCharColumn" length="42" />
+        <Column name="Identity" type="RowsetImportEngine.NVarCharColumn" length="44" />
+        <Column name="Access" type="RowsetImportEngine.VarCharColumn" length="10" />
+        <Column name="Rights" type="RowsetImportEngine.NVarCharColumn" length="128" />
+      </KnownColumns>
+    </Rowset>
+
   </KnownRowsets>
 </TextImport>

--- a/TestingInfrastructure/UnitTests/SqlNexus.UnitTests/RowsetImportEngine/ConnectivityCollectorRowsetTests.cs
+++ b/TestingInfrastructure/UnitTests/SqlNexus.UnitTests/RowsetImportEngine/ConnectivityCollectorRowsetTests.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using RowsetImportEngine;
+
+namespace SqlNexus.UnitTests.RowsetImportEngine
+{
+    /// <summary>
+    /// Regression tests for importing the SQL LogScout connectivity/security collector rowsets
+    /// (TLS protocols, client drivers, SPNs, service accounts, aliases, certificates) that were
+    /// added to TextRowsets.xml.
+    ///
+    /// These collectors emit fixed-width, sqlcmd-style output. <see cref="TextRowset"/> derives each
+    /// column's parse width from the dashed separator line (a run of dashes per column, separated by a
+    /// single space), so a too-narrow trailing dash run silently truncates the LAST column on import.
+    /// The collectors were widened so the last column (e.g. SQL_Client_Drivers 'Path',
+    /// SQL_Server_Certificates 'KeyContainerFile') is captured in full. These tests exercise the real
+    /// engine (DefineRowsetColumns + ParseRow) with that exact format to lock the contract in.
+    /// </summary>
+    [TestClass]
+    public class ConnectivityCollectorRowsetTests
+    {
+        // Build a fixed-width header line + dashed separator line the way the collectors do:
+        //   - each non-last column: name.PadRight(width)  /  (width-1) dashes then one space
+        //   - last column:          name (unpadded)       /  lastDashWidth dashes
+        private static void BuildHeaderAndDashes(string[] names, int[] widths, string lastName,
+            int lastDashWidth, out string header, out string dashes)
+        {
+            var h = new StringBuilder();
+            var d = new StringBuilder();
+            for (int i = 0; i < names.Length; i++)
+            {
+                h.Append(names[i].PadRight(widths[i]));
+                d.Append(new string('-', widths[i] - 1).PadRight(widths[i]));
+            }
+            h.Append(lastName);
+            d.Append(new string('-', lastDashWidth));
+            header = h.ToString();
+            dashes = d.ToString();
+        }
+
+        // Build a data row: non-last fields padded to their width, last field appended raw.
+        private static string BuildRow(string[] values, int[] widths, string lastValue)
+        {
+            var r = new StringBuilder();
+            for (int i = 0; i < values.Length; i++) r.Append(values[i].PadRight(widths[i]));
+            r.Append(lastValue);
+            return r.ToString();
+        }
+
+        private static string[] ColumnNames(TextRowset rs)
+        {
+            var names = new List<string>();
+            foreach (Column c in rs.Columns) names.Add(c.Name);
+            return names.ToArray();
+        }
+
+        private static string DataOf(TextRowset rs, string columnName)
+        {
+            foreach (Column c in rs.Columns)
+            {
+                if (c.Name == columnName) return c.Data == null ? null : c.Data.ToString();
+            }
+            throw new AssertFailedException("Column not found in parsed rowset: " + columnName);
+        }
+
+        private static TextRowset NewRowsetWithKnownColumns(string[] names, int sqlLen)
+        {
+            var rs = new TextRowset();
+            foreach (var n in names) rs.KnownColumns.Add(new VarCharColumn { Name = n, SqlColumnLength = sqlLen });
+            return rs;
+        }
+
+        [TestMethod]
+        public void SqlClientDrivers_Header_MapsToExpectedColumnsInOrder()
+        {
+            // Arrange: the SQL_Client_Drivers rowset header/dashes (matches GetSQLClientDrivers).
+            var names = new[] { "Name", "Type", "Version", "TLS12", "TLS13", "MSF", "Bitness", "CLSID", "Path" };
+            var rs = NewRowsetWithKnownColumns(names, 260);
+            var midNames = new[] { "Name", "Type", "Version", "TLS12", "TLS13", "MSF", "Bitness", "CLSID" };
+            var midWidths = new[] { 32, 8, 18, 9, 9, 6, 9, 40 };
+            BuildHeaderAndDashes(midNames, midWidths, "Path", 260, out string header, out string dashes);
+
+            // Act
+            rs.DefineRowsetColumns(dashes, header);
+
+            // Assert: all nine columns resolved, in order, with the exact TextRowsets.xml names.
+            CollectionAssert.AreEqual(names, ColumnNames(rs));
+        }
+
+        [TestMethod]
+        public void SqlClientDrivers_WidenedLastColumn_CapturesFullPath()
+        {
+            // Arrange
+            var names = new[] { "Name", "Type", "Version", "TLS12", "TLS13", "MSF", "Bitness", "CLSID", "Path" };
+            var rs = NewRowsetWithKnownColumns(names, 260);
+            var midNames = new[] { "Name", "Type", "Version", "TLS12", "TLS13", "MSF", "Bitness", "CLSID" };
+            var midWidths = new[] { 32, 8, 18, 9, 9, 6, 9, 40 };
+            BuildHeaderAndDashes(midNames, midWidths, "Path", 260, out string header, out string dashes);
+            rs.DefineRowsetColumns(dashes, header);
+
+            const string longPath = @"C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\170\Tools\Binn\msodbcsql17.dll";
+            string row = BuildRow(
+                new[] { "ODBC Driver 17 for SQL Server", "ODBC", "2017.1710.06.01", "Yes", "No", "Yes", "64-bit", "" },
+                midWidths, longPath);
+
+            // Act
+            rs.ParseRow(row);
+
+            // Assert: middle columns land correctly...
+            Assert.AreEqual("ODBC Driver 17 for SQL Server", DataOf(rs, "Name"));
+            Assert.AreEqual("Yes", DataOf(rs, "TLS12"));
+            Assert.AreEqual("64-bit", DataOf(rs, "Bitness"));
+            // ...and the widened trailing dash run captures the entire path. With the previous 4-dash
+            // 'Path' separator the engine returned only "C:\P"; this guards against that regression.
+            Assert.AreEqual(longPath, DataOf(rs, "Path"));
+        }
+
+        [TestMethod]
+        public void SqlSpnServiceAccounts_RenamedHeader_MapsServiceAccountNameColumn()
+        {
+            // Arrange: the SQL_SPN_ServiceAccounts rowset, whose second column header was renamed
+            // from "StartName" to "ServiceAccountName".
+            var names = new[] { "ServiceName", "ServiceAccountName", "SpnAccount", "State" };
+            var rs = NewRowsetWithKnownColumns(names, 64);
+            var midNames = new[] { "ServiceName", "ServiceAccountName", "SpnAccount" };
+            var midWidths = new[] { 24, 34, 38 };
+            BuildHeaderAndDashes(midNames, midWidths, "State", 7, out string header, out string dashes);
+            rs.DefineRowsetColumns(dashes, header);
+
+            string row = BuildRow(new[] { "MSSQL$SQL2022", "CSSLABS\\SqlSvc", "CSSLABS\\SqlSvc" }, midWidths, "Running");
+
+            // Act
+            rs.ParseRow(row);
+
+            // Assert: the renamed column is present and populated, and the last column parses.
+            CollectionAssert.AreEqual(names, ColumnNames(rs));
+            Assert.AreEqual("CSSLABS\\SqlSvc", DataOf(rs, "ServiceAccountName"));
+            Assert.AreEqual("Running", DataOf(rs, "State"));
+        }
+    }
+}

--- a/sqlnexus/TextRowsets.xml
+++ b/sqlnexus/TextRowsets.xml
@@ -4849,7 +4849,7 @@
     <!-- the dashed separator line and matches the header names below.                                   -->
     <!-- ============================================================================================== -->
 
-    <Rowset name="tbl_TLS_SSL_Protocols" enabled="true" identifier="-- TLS_SSL_Protocols --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_tls_ssl_protocols" enabled="true" identifier="-- TLS_SSL_Protocols --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Protocol" type="RowsetImportEngine.VarCharColumn" length="30" />
         <Column name="Role" type="RowsetImportEngine.VarCharColumn" length="8" />
@@ -4861,7 +4861,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Client_Drivers" enabled="true" identifier="-- SQL_Client_Drivers --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_client_drivers" enabled="true" identifier="-- SQL_Client_Drivers --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Name" type="RowsetImportEngine.VarCharColumn" length="32" />
         <Column name="Type" type="RowsetImportEngine.VarCharColumn" length="8" />
@@ -4875,7 +4875,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_SPN_ServiceAccounts" enabled="true" identifier="-- SQL_SPN_ServiceAccounts --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_spn_service_accounts" enabled="true" identifier="-- SQL_SPN_ServiceAccounts --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="ServiceName" type="RowsetImportEngine.VarCharColumn" length="24" />
         <Column name="ServiceAccountName" type="RowsetImportEngine.VarCharColumn" length="34" />
@@ -4884,7 +4884,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_SPN_Registered" enabled="true" identifier="-- SQL_SPN_Registered --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_spn_registered" enabled="true" identifier="-- SQL_SPN_Registered --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="38" />
         <Column name="SPN" type="RowsetImportEngine.VarCharColumn" length="54" />
@@ -4893,7 +4893,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_SPN_Suggested" enabled="true" identifier="-- SQL_SPN_Suggested --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_spn_suggested" enabled="true" identifier="-- SQL_SPN_Suggested --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="20" />
         <Column name="SuggestedSPN" type="RowsetImportEngine.VarCharColumn" length="54" />
@@ -4902,7 +4902,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Service_Summary" enabled="true" identifier="-- SQL_Service_Summary --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_service_summary" enabled="true" identifier="-- SQL_Service_Summary --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="18" />
         <Column name="ServiceName" type="RowsetImportEngine.VarCharColumn" length="22" />
@@ -4912,7 +4912,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Service_Account_Delegation" enabled="true" identifier="-- SQL_Service_Account_Delegation --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_service_account_delegation" enabled="true" identifier="-- SQL_Service_Account_Delegation --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="24" />
         <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="28" />
@@ -4920,14 +4920,14 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_Kerberos_Local_Policy" enabled="true" identifier="-- Kerberos_Local_Policy --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_kerberos_local_policy" enabled="true" identifier="-- Kerberos_Local_Policy --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="28" />
         <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="256" />
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Instance_Network_Security" enabled="true" identifier="-- SQL_Instance_Network_Security --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_instance_network_security" enabled="true" identifier="-- SQL_Instance_Network_Security --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="18" />
         <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="24" />
@@ -4935,7 +4935,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Client_Aliases" enabled="true" identifier="-- SQL_Client_Aliases --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_client_aliases" enabled="true" identifier="-- SQL_Client_Aliases --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="Alias" type="RowsetImportEngine.VarCharColumn" length="28" />
         <Column name="Architecture" type="RowsetImportEngine.VarCharColumn" length="14" />
@@ -4946,7 +4946,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Server_Certificates" enabled="true" identifier="-- SQL_Server_Certificates --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_server_certificates" enabled="true" identifier="-- SQL_Server_Certificates --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="CertID" type="RowsetImportEngine.VarCharColumn" length="7" />
         <Column name="Thumbprint" type="RowsetImportEngine.VarCharColumn" length="42" />
@@ -4965,7 +4965,7 @@
       </KnownColumns>
     </Rowset>
 
-    <Rowset name="tbl_SQL_Server_Certificate_KeyAcl" enabled="true" identifier="-- SQL_Server_Certificate_KeyAcl --" type="RowsetImportEngine.TextRowset">
+    <Rowset name="tbl_sql_server_certificate_key_acl" enabled="true" identifier="-- SQL_Server_Certificate_KeyAcl --" type="RowsetImportEngine.TextRowset">
       <KnownColumns>
         <Column name="CertID" type="RowsetImportEngine.VarCharColumn" length="7" />
         <Column name="Thumbprint" type="RowsetImportEngine.VarCharColumn" length="42" />

--- a/sqlnexus/TextRowsets.xml
+++ b/sqlnexus/TextRowsets.xml
@@ -4842,5 +4842,138 @@
       </KnownColumns>
     </Rowset>  
     
+    <!-- ============================================================================================== -->
+    <!-- SQL LogScout connectivity & security collectors (TLS protocols, client drivers, SPNs, service   -->
+    <!-- accounts, client aliases, server certificates). One rowset per section emitted by each          -->
+    <!-- collector's .out file. Output is fixed-width sqlcmd-style; the engine derives column widths from -->
+    <!-- the dashed separator line and matches the header names below.                                   -->
+    <!-- ============================================================================================== -->
+
+    <Rowset name="tbl_TLS_SSL_Protocols" enabled="true" identifier="-- TLS_SSL_Protocols --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Protocol" type="RowsetImportEngine.VarCharColumn" length="30" />
+        <Column name="Role" type="RowsetImportEngine.VarCharColumn" length="8" />
+        <Column name="RegEnabled" type="RowsetImportEngine.VarCharColumn" length="12" />
+        <Column name="RegDisabledByDefault" type="RowsetImportEngine.VarCharColumn" length="22" />
+        <Column name="EffectiveState" type="RowsetImportEngine.VarCharColumn" length="30" />
+        <Column name="Source" type="RowsetImportEngine.VarCharColumn" length="20" />
+        <Column name="RegistryPath" type="RowsetImportEngine.VarCharColumn" length="160" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Client_Drivers" enabled="true" identifier="-- SQL_Client_Drivers --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Name" type="RowsetImportEngine.VarCharColumn" length="32" />
+        <Column name="Type" type="RowsetImportEngine.VarCharColumn" length="8" />
+        <Column name="Version" type="RowsetImportEngine.VarCharColumn" length="18" />
+        <Column name="TLS12" type="RowsetImportEngine.VarCharColumn" length="9" />
+        <Column name="TLS13" type="RowsetImportEngine.VarCharColumn" length="9" />
+        <Column name="MSF" type="RowsetImportEngine.VarCharColumn" length="6" />
+        <Column name="Bitness" type="RowsetImportEngine.VarCharColumn" length="9" />
+        <Column name="CLSID" type="RowsetImportEngine.VarCharColumn" length="40" />
+        <Column name="Path" type="RowsetImportEngine.VarCharColumn" length="260" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_SPN_ServiceAccounts" enabled="true" identifier="-- SQL_SPN_ServiceAccounts --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="ServiceName" type="RowsetImportEngine.VarCharColumn" length="24" />
+        <Column name="ServiceAccountName" type="RowsetImportEngine.VarCharColumn" length="34" />
+        <Column name="SpnAccount" type="RowsetImportEngine.VarCharColumn" length="38" />
+        <Column name="State" type="RowsetImportEngine.VarCharColumn" length="16" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_SPN_Registered" enabled="true" identifier="-- SQL_SPN_Registered --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="38" />
+        <Column name="SPN" type="RowsetImportEngine.VarCharColumn" length="54" />
+        <Column name="Type" type="RowsetImportEngine.VarCharColumn" length="12" />
+        <Column name="Duplicate" type="RowsetImportEngine.VarCharColumn" length="10" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_SPN_Suggested" enabled="true" identifier="-- SQL_SPN_Suggested --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="20" />
+        <Column name="SuggestedSPN" type="RowsetImportEngine.VarCharColumn" length="54" />
+        <Column name="ExpectedAccount" type="RowsetImportEngine.VarCharColumn" length="24" />
+        <Column name="Status" type="RowsetImportEngine.VarCharColumn" length="64" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Service_Summary" enabled="true" identifier="-- SQL_Service_Summary --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="18" />
+        <Column name="ServiceName" type="RowsetImportEngine.VarCharColumn" length="22" />
+        <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="40" />
+        <Column name="StartMode" type="RowsetImportEngine.VarCharColumn" length="10" />
+        <Column name="State" type="RowsetImportEngine.VarCharColumn" length="16" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Service_Account_Delegation" enabled="true" identifier="-- SQL_Service_Account_Delegation --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Account" type="RowsetImportEngine.VarCharColumn" length="24" />
+        <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="28" />
+        <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="256" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_Kerberos_Local_Policy" enabled="true" identifier="-- Kerberos_Local_Policy --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="28" />
+        <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="256" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Instance_Network_Security" enabled="true" identifier="-- SQL_Instance_Network_Security --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Instance" type="RowsetImportEngine.VarCharColumn" length="18" />
+        <Column name="Property" type="RowsetImportEngine.VarCharColumn" length="24" />
+        <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="64" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Client_Aliases" enabled="true" identifier="-- SQL_Client_Aliases --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="Alias" type="RowsetImportEngine.VarCharColumn" length="28" />
+        <Column name="Architecture" type="RowsetImportEngine.VarCharColumn" length="14" />
+        <Column name="Protocol" type="RowsetImportEngine.VarCharColumn" length="20" />
+        <Column name="Server" type="RowsetImportEngine.NVarCharColumn" length="48" />
+        <Column name="Port" type="RowsetImportEngine.VarCharColumn" length="8" />
+        <Column name="Value" type="RowsetImportEngine.NVarCharColumn" length="128" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Server_Certificates" enabled="true" identifier="-- SQL_Server_Certificates --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="CertID" type="RowsetImportEngine.VarCharColumn" length="7" />
+        <Column name="Thumbprint" type="RowsetImportEngine.VarCharColumn" length="42" />
+        <Column name="Subject" type="RowsetImportEngine.NVarCharColumn" length="40" />
+        <Column name="SubjectAltNames" type="RowsetImportEngine.NVarCharColumn" length="34" />
+        <Column name="ServerCert" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="NotBefore" type="RowsetImportEngine.DateTimeColumn" />
+        <Column name="NotAfter" type="RowsetImportEngine.DateTimeColumn" />
+        <Column name="Validity" type="RowsetImportEngine.VarCharColumn" length="13" />
+        <Column name="HasPrivKey" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="Exportable" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="KeyProv" type="RowsetImportEngine.VarCharColumn" length="9" />
+        <Column name="SqlAccess" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="SqlUsed" type="RowsetImportEngine.VarCharColumn" length="11" />
+        <Column name="KeyContainerFile" type="RowsetImportEngine.NVarCharColumn" length="260" />
+      </KnownColumns>
+    </Rowset>
+
+    <Rowset name="tbl_SQL_Server_Certificate_KeyAcl" enabled="true" identifier="-- SQL_Server_Certificate_KeyAcl --" type="RowsetImportEngine.TextRowset">
+      <KnownColumns>
+        <Column name="CertID" type="RowsetImportEngine.VarCharColumn" length="7" />
+        <Column name="Thumbprint" type="RowsetImportEngine.VarCharColumn" length="42" />
+        <Column name="Identity" type="RowsetImportEngine.NVarCharColumn" length="44" />
+        <Column name="Access" type="RowsetImportEngine.VarCharColumn" length="10" />
+        <Column name="Rights" type="RowsetImportEngine.NVarCharColumn" length="128" />
+      </KnownColumns>
+    </Rowset>
+
   </KnownRowsets>
 </TextImport>


### PR DESCRIPTION
This pull request adds support for importing and testing a new set of SQL LogScout connectivity and security collector rowsets. These rowsets cover TLS protocols, SQL client drivers, SPNs, service accounts, client aliases, and server certificates, and are now defined in both `TextRowsets.xml` files. Additionally, new regression tests ensure the import engine correctly parses these fixed-width, sqlcmd-style outputs, especially for edge cases like wide trailing columns and renamed headers.

The following tables have been created

select * from [tbl_tls_ssl_protocols]
select * from [tbl_sql_client_drivers]
select * from [tbl_sql_spn_service_accounts]
select * from [tbl_sql_spn_registered]
select * from [tbl_sql_spn_suggested]
select * from [tbl_sql_service_summary]
select * from [tbl_sql_service_account_delegation]
select * from [tbl_kerberos_local_policy]
select * from [tbl_sql_instance_network_security]
select * from [tbl_sql_client_aliases]
select * from [tbl_sql_server_certificates]
select * from [tbl_sql_server_certificate_key_acl]



**Rowset Definitions and Import Support:**

* Added definitions for new SQL LogScout connectivity and security collector rowsets in both `RowsetImportEngine/TextRowsets.xml` and `sqlnexus/TextRowsets.xml`. These include rowsets for TLS/SSL protocols, SQL client drivers, SPN service accounts and registrations, service summaries, Kerberos policy, client aliases, server certificates, and related key ACLs. Each rowset specifies known columns and their types/widths to support fixed-width import.

**Testing and Validation:**

* Introduced a new test class `ConnectivityCollectorRowsetTests` in `ConnectivityCollectorRowsetTests.cs` to provide regression coverage for these rowsets. The tests verify that:
  - Column headers are mapped in the correct order.
  - Widened trailing columns (such as the `Path` field in client drivers) are fully captured, preventing silent truncation.
  - Renamed headers (e.g., `ServiceAccountName` instead of `StartName`) are correctly recognized and parsed.